### PR TITLE
Ignore "layer" and "topology" tables in rake db:schema:dump

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -102,3 +102,5 @@ require 'active_record/connection_adapters/postgis_adapter/arel_tosql.rb'
 ignore_tables_ = ::ActiveRecord::SchemaDumper.ignore_tables
 ignore_tables_ << 'geometry_columns' unless ignore_tables_.include?('geometry_columns')
 ignore_tables_ << 'spatial_ref_sys' unless ignore_tables_.include?('spatial_ref_sys')
+ignore_tables_ << 'layer' unless ignore_tables_.include?('layer')
+ignore_tables_ << 'topology' unless ignore_tables_.include?('topology')


### PR DESCRIPTION
These tables were added by the postgis_topology extension in postgis 2.0.1, and they were ending up in my schema.rb. So, I added them to the list of tables to ignore.
