### PR TITLE
Allow WKT to be to be specified as a string-like object rather than having to be a String.

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
@@ -165,11 +165,11 @@ module ActiveRecord
           else
             constraints_ = nil
           end
-          case input_
-          when ::RGeo::Feature::Geometry
+          if ::RGeo::Feature::Geometry === input_
             factory_ = factory_settings_.get_column_factory(table_name_, column_, constraints_)
             ::RGeo::Feature.cast(input_, factory_) rescue nil
-          when ::String
+          elsif input_.respond_to?(:to_str)
+            input_ = input_.to_str
             if input_.length == 0
               nil
             else


### PR DESCRIPTION
We're using a "string-like object" to hold WKT rather than String.  After all, WKT cannot be any arbitrary string, it has to have a very specific format.  This patch lets us assign our objects to a field.
