### PR TITLE
Create schemas specified in schema_search_path only if they don't exits

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/databases.rake
@@ -68,7 +68,8 @@ def create_database(config_)
       search_path_ = search_path_.split(",").map{ |sp_| sp_.strip }
       auth_ = has_su_ ? " AUTHORIZATION #{username_}" : ''
       search_path_.each do |schema_|
-        conn_.execute("CREATE SCHEMA #{schema_}#{auth_}") unless schema_.downcase == 'public'
+        exists = schema_.downcase == 'public' || conn_.execute("SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname='#{schema_}'").try(:first)
+        conn_.execute("CREATE SCHEMA #{schema_}#{auth_}") unless exists
       end
 
       # Install postgis definitions into the database.


### PR DESCRIPTION
If I set template and schema_search_path and define schema in template, that is described in schema_search_path, I get an error. This change fixes the error.
