### PR TITLE
Add JRuby compatibility

### DIFF
--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -51,5 +51,4 @@
   s_.test_files = ::Dir.glob("test/**/tc_*.rb")
   s_.platform = ::Gem::Platform::RUBY
   s_.add_dependency('rgeo-activerecord', '~> 0.4.5')
-  s_.add_dependency('pg', '>= 0.11.0')
 end

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -35,45 +35,18 @@
 
 
 require 'rgeo/active_record'
-require 'active_record/connection_adapters/postgresql_adapter'
+
+if(defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
+  require 'active_record/connection_adapters/postgis_adapter/jdbc_connection'
+else
+  require 'active_record/connection_adapters/postgis_adapter/pg_connection'
+end
 
 
 # The activerecord-postgis-adapter gem installs the *postgis*
 # connection adapter into ActiveRecord.
 
 module ActiveRecord
-
-
-  # ActiveRecord looks for the postgis_connection factory method in
-  # this class.
-
-  class Base
-
-
-    # Create a postgis connection adapter.
-
-    def self.postgis_connection(config_)
-      require 'pg'
-
-      config_ = config_.symbolize_keys
-      host_ = config_[:host]
-      port_ = config_[:port] || 5432
-      username_ = config_[:username].to_s if config_[:username]
-      password_ = config_[:password].to_s if config_[:password]
-      if config_.has_key?(:database)
-        database_ = config_[:database]
-      else
-        raise ::ArgumentError, "No database specified. Missing argument: database."
-      end
-
-      # The postgres drivers don't allow the creation of an unconnected PGconn object,
-      # so just pass a nil connection object for the time being.
-      ::ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter.new(nil, logger, [host_, port_, nil, nil, database_, username_, password_], config_)
-    end
-
-
-  end
-
 
   # All ActiveRecord adapters go in this namespace.
   module ConnectionAdapters

--- a/lib/active_record/connection_adapters/postgis_adapter/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/jdbc_connection.rb
@@ -1,0 +1,56 @@
+require 'active_record/connection_adapters/jdbcpostgresql_adapter'
+
+# Extend JDBC's PostgreSQLAdapter implementation for compatibility with
+# ActiveRecord's default PostgreSQLAdapter.
+class ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  # Add `query` method for compatibility
+  def query(*args)
+    select_rows(*args)
+  end
+
+  # Backport from master, so PostGIS adapater will work with current stable
+  # activerecord-jdbc-adapter gem.
+  #
+  # https://github.com/jruby/activerecord-jdbc-adapter/pull/200
+  unless method_defined?(:schema_search_path=)
+    def schema_search_path=(schema_csv)
+      if schema_csv
+        execute "SET search_path TO #{schema_csv}"
+        @schema_search_path = schema_csv
+      end
+    end
+  end
+
+  # Backport from master, so PostGIS adapater will work with current stable
+  # activerecord-jdbc-adapter gem.
+  #
+  # https://github.com/jruby/activerecord-jdbc-adapter/pull/200
+  unless method_defined?(:schema_search_path)
+    # Returns the active schema search path.
+    def schema_search_path
+      @schema_search_path ||= exec_query('SHOW search_path', 'SCHEMA')[0]['search_path']
+    end
+  end
+end
+
+class ::ActiveRecord::Base
+  # ActiveRecord looks for the postgis_connection factory method in
+  # this class.
+  #
+  # Based on the default `postgresql_connection` definition from
+  # activerecord-jdbc-adapter's:
+  # lib/arjdbc/postgresql/connection_methods.rb
+  def self.postgis_connection(config)
+    require "arjdbc/postgresql"
+    config[:host] ||= "localhost"
+    config[:port] ||= 5432
+    config[:url] ||= "jdbc:postgresql://#{config[:host]}:#{config[:port]}/#{config[:database]}"
+    config[:url] << config[:pg_params] if config[:pg_params]
+    config[:driver] ||= "org.postgresql.Driver"
+    config[:adapter_class] = ::ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter
+    config[:adapter_spec] = ::ArJdbc::PostgreSQL
+    conn = jdbc_connection(config)
+    conn.execute("SET SEARCH_PATH TO #{config[:schema_search_path]}") if config[:schema_search_path]
+    conn
+  end
+end

--- a/lib/active_record/connection_adapters/postgis_adapter/pg_connection.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/pg_connection.rb
@@ -1,0 +1,27 @@
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class ::ActiveRecord::Base
+  # ActiveRecord looks for the postgis_connection factory method in
+  # this class.
+  #
+  # Based on the default `postgresql_connection` definition from
+  # activerecord's:
+  # lib/active_record/connection_adapters/postgresql_adapter.rb
+  def self.postgis_connection(config)
+    config = config.symbolize_keys
+    host     = config[:host]
+    port     = config[:port] || 5432
+    username = config[:username].to_s if config[:username]
+    password = config[:password].to_s if config[:password]
+
+    if config.key?(:database)
+      database = config[:database]
+    else
+      raise ArgumentError, "No database specified. Missing argument: database."
+    end
+
+    # The postgres drivers don't allow the creation of an unconnected PGconn object,
+    # so just pass a nil connection object for the time being.
+    ::ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter.new(nil, logger, [host, port, nil, nil, database, username, password], config)
+  end
+end


### PR DESCRIPTION
I'm exploring switching our apps to JRuby, but we depend on this gem for postgis work. With a few small tweaks, I was able to get this gem working under JRuby with [activerecord-jdbcpostgresql-adapter](http://rubygems.org/gems/activerecord-jdbcpostgresql-adapter) (which provides a nearly drop-in replacement for the default `PostgreSQLAdapter` class `PostGISAdapter::MainAdapter` inherits from).

[RGeo](https://github.com/dazuma/rgeo#dependencies) notes that JRuby is only partially supported, but with `ffi-geos` also installed, the postgis adapter seems to at least meet our PostGIS needs, so I thought this basic JRuby support might be helpful to others.

The only backwards compatibility issue is that I removed `pg` as a direct gem dependency, so it's up to the user to either install `pg` or `activerecord-jdbcpostgresql-adapter` depending on their platform. But this is similar to how activerecord deals with postgres by default (`pg` isn't installed, but you'll get a message about adding it to your bundle).

I wasn't able to get activerecord-postgis-adapter's own tests to run (even under MRI Ruby and before I made changes), but our app's complete test suite passes while using this fork under both JRuby and MRI Ruby (both 1.9). For activerecord-postgis-adapter's own tests, I might just be missing something, but I only got errors like:

`NameError: uninitialized constant RGeo::ActiveRecord::PostGISAdapter::Tests::TestSpatialQueries::DEFAULT_AR_CLASS`
