### PR TITLE
Support postgis extension postgis_topology in Database.yml 

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/databases.rake
@@ -97,7 +97,12 @@ def create_database(config_)
           postgis_extension_ = 'postgis' if postgis_extension_ == true
           postgis_extension_ = postgis_extension_.to_s.split(',') unless postgis_extension_.is_a?(::Array)
           postgis_extension_.each do |extname_|
-            conn_.execute("CREATE EXTENSION #{extname_} SCHEMA #{postgis_schema_}")
+            if extname_ == 'postgis_topology'
+              raise ArgumentError, "'topology' must be in schema_search_path for postgis_topology" unless search_path_.include?('topology')
+              conn_.execute("CREATE EXTENSION #{extname_} SCHEMA topology")
+            else
+              conn_.execute("CREATE EXTENSION #{extname_} SCHEMA #{postgis_schema_}")
+            end
           end
         end
         if has_su_


### PR DESCRIPTION
Support the following database.yml so topology extensions are automatically created with db:

``` yaml
defaults: &defaults
  adapter: postgis
  encoding: unicode
  pool: 5
  postgis_extension: postgis,postgis_topology
  schema_search_path: public,topology 
  # Intentionally left off postgis, see below.

development:
  database: database_development
  <<: *defaults

test:
  database: database_test
  <<: *defaults

production:
  database: database_production
  <<: *defaults

```

Before, it would attempt to create all extensions in the 'postgis' schema or, if no postgis schema exists, the last schema listed. The postgis_topology extension however requires the 'topology' schema.

``` yaml
  schema_search_path: public,topology 
  # Intentionally left off postgis, see below.
```

The above line was done as such because the `CREATE EXTENSION postgis_topology` creates all functions assuming the postgis types are in the public schema, not the postgis schema (ie: geometry not postgis.geometry). This means that if you use the default below

``` yaml
  schema_search_path: public,postgis,topology
```

you will need to cast every `postgis.geometry` to `geometry` in your sql when using the topology functions:

``` sql
-- with postgis schema
SELECT st_simplify(geometry, 100) FROM regions;

-- ERROR:  function st_simplify(postgis.geometry, integer) does not exist
-- LINE 1: SELECT st_simplify(geometry, 100) FROM regions LIMIT 1;
--                           ^
-- HINT:  No function matches the given name and argument types. You might need to add explicit type casts.


SELECT st_simplify(ST_GeomFromEWKB(geometry), 100) FROM regions; 
```

Gets annoying.
