### PR TITLE
rake task to setup GIS data after db has been created

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/databases.rake
@@ -43,14 +43,101 @@ class Object
 end
 
 
+namespace :db do
+  namespace :gis do
+    desc "Setup PostGIS data in the database"
+    task :setup => [:load_config, :rails_env] do
+      configs_for_environment.each { |config| setup_gis(config) }
+    end
+  end
+end
+
+
+# superuser name/password
+def get_su_auth(config_)
+  username_ = config_['username']
+  su_username_ = config_['su_username'] || username_
+  su_password_ = config_['su_password'] || config_['password']
+
+  [ username_, su_username_, su_password_ ]
+end
+
+
+def get_search_path(config_)
+  config_["schema_search_path"].to_s.strip.split(',').map(&:strip)
+end
+
+
+# Install postgis definitions into the database.
+# Note: a superuser is required to run the postgis definitions.
+# If a separate superuser is provided, we need to grant privileges on
+# the postgis definitions over to the regular user afterwards.
+# We also need to set the ownership of the postgis tables (spatial_ref_sys
+# and geometry_columns) to the regular user. This is required to e.g.
+# be able to disable referential integrity on the database when using
+# a database cleaner truncation strategy during testing.
+# The schema for the postgis definitions is chosen as follows:
+# If "postgis" is present in the search path, use it.
+# Otherwise, use the last schema in the search path.
+# If no search path is given, use "public".
+def setup_gis_(config_)
+  # Initial setup of the database: Add schemas from the search path.
+  # If a superuser is given, we log in as the superuser, but we make sure
+  # the schemas are owned by the regular user.
+  ::ActiveRecord::Base.establish_connection(config_.merge('schema_search_path' => 'public', 'username' => su_username_, 'password' => su_password_))
+  conn_ = ::ActiveRecord::Base.connection
+  search_path_ = get_search_path(config_)
+  auth_ = has_su_ ? " AUTHORIZATION #{username_}" : ''
+  search_path_.each do |schema_|
+    exists = schema_.downcase == 'public' || conn_.execute("SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname='#{schema_}'").try(:first)
+    conn_.execute("CREATE SCHEMA #{schema_}#{auth_}") unless exists
+  end
+
+
+  script_dir_ = config_['script_dir']
+  postgis_extension_ = config_['postgis_extension']
+  if script_dir_ || postgis_extension_
+    postgis_schema_ = search_path_.include?('postgis') ? 'postgis' : (search_path_.last || 'public')
+    if script_dir_
+      # Use script_dir (for postgresql < 9.1 or postgis < 2.0)
+      conn_.execute("SET search_path TO #{postgis_schema_}")
+      conn_.execute(::File.read(::File.expand_path('postgis.sql', script_dir_)))
+      conn_.execute(::File.read(::File.expand_path('spatial_ref_sys.sql', script_dir_)))
+    elsif postgis_extension_
+      # Use postgis_extension (for postgresql >= 9.1 and postgis >= 2.0)
+      postgis_extension_ = 'postgis' if postgis_extension_ == true
+      postgis_extension_ = postgis_extension_.to_s.split(',') unless postgis_extension_.is_a?(::Array)
+      postgis_extension_.each do |extname_|
+        if extname_ == 'postgis_topology'
+          raise ArgumentError, "'topology' must be in schema_search_path for postgis_topology" unless search_path_.include?('topology')
+          conn_.execute("CREATE EXTENSION #{extname_} SCHEMA topology")
+        else
+          conn_.execute("CREATE EXTENSION #{extname_} SCHEMA #{postgis_schema_}")
+        end
+      end
+    end
+    if has_su_
+      conn_.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA #{postgis_schema_} TO #{username_}")
+      conn_.execute("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA #{postgis_schema_} TO #{username_}")
+
+      postgis_version = conn_.execute( "SELECT #{postgis_schema_}.postgis_version();" ).first[ 'postgis_version' ]
+      if postgis_version =~ /^2/
+        conn_.execute("ALTER VIEW #{postgis_schema_}.geometry_columns OWNER TO #{username_}")
+      else
+        conn_.execute("ALTER TABLE #{postgis_schema_}.geometry_columns OWNER TO #{username_}")
+      end
+      conn_.execute("ALTER TABLE #{postgis_schema_}.spatial_ref_sys OWNER TO #{username_}")
+    end
+  end
+end
+
+
 def create_database(config_)
   if config_['adapter'] == 'postgis'
     @encoding = config_['encoding'] || ::ENV['CHARSET'] || 'utf8'
     begin
       has_su_ = config_.include?('su_username')            # Is there a distinct superuser?
-      username_ = config_['username']                      # regular user name
-      su_username_ = config_['su_username'] || username_   # superuser name
-      su_password_ = config_['su_password'] || config_['password']  # superuser password
+      username_, su_username_, su_password_ = get_su_auth(config_)
 
       # Create the database. Optionally do so as the given superuser.
       # But make sure the database is owned by the regular user.
@@ -59,66 +146,8 @@ def create_database(config_)
       extra_configs_['owner'] = username_ if has_su_
       ::ActiveRecord::Base.connection.create_database(config_['database'], config_.merge(extra_configs_))
 
-      # Initial setup of the database: Add schemas from the search path.
-      # If a superuser is given, we log in as the superuser, but we make sure
-      # the schemas are owned by the regular user.
-      ::ActiveRecord::Base.establish_connection(config_.merge('schema_search_path' => 'public', 'username' => su_username_, 'password' => su_password_))
-      conn_ = ::ActiveRecord::Base.connection
-      search_path_ = config_["schema_search_path"].to_s.strip
-      search_path_ = search_path_.split(",").map{ |sp_| sp_.strip }
-      auth_ = has_su_ ? " AUTHORIZATION #{username_}" : ''
-      search_path_.each do |schema_|
-        exists = schema_.downcase == 'public' || conn_.execute("SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname='#{schema_}'").try(:first)
-        conn_.execute("CREATE SCHEMA #{schema_}#{auth_}") unless exists
-      end
+      setup_gis(config_)
 
-      # Install postgis definitions into the database.
-      # Note: a superuser is required to run the postgis definitions.
-      # If a separate superuser is provided, we need to grant privileges on
-      # the postgis definitions over to the regular user afterwards.
-      # We also need to set the ownership of the postgis tables (spatial_ref_sys
-      # and geometry_columns) to the regular user. This is required to e.g.
-      # be able to disable referential integrity on the database when using
-      # a database cleaner truncation strategy during testing.
-      # The schema for the postgis definitions is chosen as follows:
-      # If "postgis" is present in the search path, use it.
-      # Otherwise, use the last schema in the search path.
-      # If no search path is given, use "public".
-      script_dir_ = config_['script_dir']
-      postgis_extension_ = config_['postgis_extension']
-      if script_dir_ || postgis_extension_
-        postgis_schema_ = search_path_.include?('postgis') ? 'postgis' : (search_path_.last || 'public')
-        if script_dir_
-          # Use script_dir (for postgresql < 9.1 or postgis < 2.0)
-          conn_.execute("SET search_path TO #{postgis_schema_}")
-          conn_.execute(::File.read(::File.expand_path('postgis.sql', script_dir_)))
-          conn_.execute(::File.read(::File.expand_path('spatial_ref_sys.sql', script_dir_)))
-        elsif postgis_extension_
-          # Use postgis_extension (for postgresql >= 9.1 and postgis >= 2.0)
-          postgis_extension_ = 'postgis' if postgis_extension_ == true
-          postgis_extension_ = postgis_extension_.to_s.split(',') unless postgis_extension_.is_a?(::Array)
-          postgis_extension_.each do |extname_|
-            if extname_ == 'postgis_topology'
-              raise ArgumentError, "'topology' must be in schema_search_path for postgis_topology" unless search_path_.include?('topology')
-              conn_.execute("CREATE EXTENSION #{extname_} SCHEMA topology")
-            else
-              conn_.execute("CREATE EXTENSION #{extname_} SCHEMA #{postgis_schema_}")
-            end
-          end
-        end
-        if has_su_
-          conn_.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA #{postgis_schema_} TO #{username_}")
-          conn_.execute("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA #{postgis_schema_} TO #{username_}")
-
-          postgis_version = conn_.execute( "SELECT #{postgis_schema_}.postgis_version();" ).first[ 'postgis_version' ]
-          if postgis_version =~ /^2/
-            conn_.execute("ALTER VIEW #{postgis_schema_}.geometry_columns OWNER TO #{username_}")
-          else
-            conn_.execute("ALTER TABLE #{postgis_schema_}.geometry_columns OWNER TO #{username_}")
-          end
-          conn_.execute("ALTER TABLE #{postgis_schema_}.spatial_ref_sys OWNER TO #{username_}")
-        end
-      end
 
       # Done
       ::ActiveRecord::Base.establish_connection(config_)


### PR DESCRIPTION
This refactors the database rake tasks slightly so that the PostGIS data can be setup during `rake db:create` or in a separate rake task, which I've called `rake db:gis:setup`. My intent is to make it easier for someone to switch to the postgis adapter from another one.
