### PR TITLE
Refactored SpatialColumn initialization arguments to be compatible with postgres_ext

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
@@ -130,8 +130,11 @@ module ActiveRecord
               col_name_ = col_name_["column_name"]
             end
 
-            SpatialColumn.new(@rgeo_factory_settings, table_name_, col_name_, default_, type_,
-              notnull_ == 'f', type_ =~ /geometry/i ? spatial_info_[col_name_] : nil)
+            SpatialColumn.new(col_name_, default_, type_, notnull_ == 'f',
+              ((type_ =~ /geometry/i ? spatial_info_[col_name_] : nil) || {}).merge({
+                  :table_name => table_name_,
+                  :factory_settings => @rgeo_factory_settings
+                }))
           end
         end
 

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
@@ -49,11 +49,11 @@ module ActiveRecord
         FACTORY_SETTINGS_CACHE = {}
 
 
-        def initialize(factory_settings_, table_name_, name_, default_, sql_type_=nil, null_=true, opts_=nil)
-          @factory_settings = factory_settings_
-          @table_name = table_name_
+        def initialize(name_, default_, sql_type_=nil, null_=true, opts_={})
+          @factory_settings = opts_.delete(:factory_settings)
+          @table_name = opts_.delete(:table_name)
           @geographic = sql_type_ =~ /geography/i ? true : false
-          if opts_
+          if opts_.length > 0
             # This case comes from an entry in the geometry_columns table
             @geometric_type = ::RGeo::ActiveRecord.geometric_type_from_name(opts_[:type]) ||
               ::RGeo::Feature::Geometry
@@ -97,7 +97,7 @@ module ActiveRecord
               @limit = {:no_constraints => true}
             end
           end
-          FACTORY_SETTINGS_CACHE[factory_settings_.object_id] = factory_settings_
+          FACTORY_SETTINGS_CACHE[@factory_settings.object_id] = @factory_settings
         end
 
 


### PR DESCRIPTION
I made a pull request to postgres_ext as well, so it can be extended by activerecord-postgis-adapter gem.

After these changes the activerecord-postgis-adapter and postres_ext can be used together, although postgres_ext must be required before postgis in application.rb file.
