### PR TITLE
Update lib/active_record/connection_adapters/postgis_adapter/spatial_tab...

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_table_definition.rb
@@ -42,8 +42,13 @@ module ActiveRecord
 
     module PostGISAdapter
 
+      TableDefinitionSuperclass = if defined?(ConnectionAdapters::PostgreSQLAdapter::TableDefinition)
+        ConnectionAdapters::PostgreSQLAdapter::TableDefinition
+      else
+        ConnectionAdapters::TableDefinition
+      end
 
-      class SpatialTableDefinition < ConnectionAdapters::PostgreSQLAdapter::TableDefinition
+      class SpatialTableDefinition < TableDefinitionSuperclass
 
         def column(name_, type_, options_={})
           if (info_ = @base.spatial_column_constructor(type_.to_sym))


### PR DESCRIPTION
SpatialTableDefinition should subclass from ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::TableDefinition instead of ActiveRecord::ConnectionAdapters::TableDefinition.  This way it will not lose added instance methods such as #tsvector for column creation, and schema.rb files will work properly.
