### PR TITLE
Maintain superuser permissions during database creation in rails4

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
@@ -69,7 +69,9 @@ module ActiveRecord  # :nodoc:
           extra_configs_ = {'encoding' => encoding}
           extra_configs_['owner'] = username if has_su?
           connection.create_database(configuration['database'], configuration.merge(extra_configs_))
-          establish_connection(configuration) unless master_established_
+          establish_connection(configuration.merge(
+            'username' => su_username,
+            'password' => su_password)) unless master_established_
           setup_gis
         rescue ::ActiveRecord::StatementInvalid => error_
           if /database .* already exists/ === error_.message
@@ -183,7 +185,9 @@ module ActiveRecord  # :nodoc:
               connection.execute("CREATE SCHEMA #{schema_}#{auth_}")
             end
           end
-          establish_connection(configuration)
+          establish_connection(configuration.merge(
+            'username' => su_username,
+            'password' => su_password))
         end
 
 


### PR DESCRIPTION
In postgis_database_tasks.rb under Rails 4, there were a couple of calls to establish_connect() that didn't provide su_username and su_password as the username and password.  As a result, the connection would revert to the normal user, and CREATE EXTENSION would fail if the normal user wasn't a superuser.  I've added the configuration params where appropriate.
