### PR TITLE
Fix database setup rake tasks under jruby/jdbc adapter

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
@@ -92,7 +92,7 @@ def setup_gis(config_)
   ::ActiveRecord::Base.establish_connection(config_.merge('schema_search_path' => 'public', 'username' => su_username_, 'password' => su_password_))
   conn_ = ::ActiveRecord::Base.connection
   search_path_ = get_search_path(config_)
-  quoted_username_ = ::PGconn.quote_ident(username_)
+  quoted_username_ = ::ActiveRecord::Base.connection.quote_column_name(username_)
   auth_ = has_su_ ? " AUTHORIZATION #{quoted_username_}" : ''
   search_path_.each do |schema_|
     exists = schema_.downcase == 'public' || conn_.execute("SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname='#{schema_}'").try(:first)

--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
@@ -113,7 +113,7 @@ module ActiveRecord  # :nodoc:
         end
 
         def quoted_username
-          @quoted_username ||= ::PGconn.quote_ident(username)
+          @quoted_username ||= ::ActiveRecord::Base.connection.quote_column_name(username)
         end
 
         def password


### PR DESCRIPTION
The current rake tasks used to create the database are broken under jruby due to it using PGconn.quote_ident (which only works with the pg c extension). This fixes it to use a quote method that will work under all implementations.

I couldn't figure out how to add a test case for this since it's a buried in the rails 3 rake task, but I think this should be good for all setups. And the rails 4 test cases you've added should cover this once the jdbc adapter works against rails 4, so that should eventually provide some coverage.

ActiveRecord's quote_column_name is equivalent to pg's quote_ident.
Under activerecord's default adapter it actually just calls quote_ident,
while under the jdbc adpater it provides a ruby-based implementation.
