### PR TITLE
Database rake tasks take into account "username".

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
@@ -179,6 +179,7 @@ def set_psql_env(config_)
   ::ENV['PGHOST'] = config_["host"] if config_["host"]
   ::ENV['PGPORT'] = config_["port"].to_s if config_["port"]
   ::ENV['PGPASSWORD'] = config_["password"].to_s if config_["password"]
+  ::ENV['PGUSER'] = config_["username"].to_s if config_["username"]
 end
 
 


### PR DESCRIPTION
Hello Daniel,

please accept my request to your gem.

The problem, I've encountered: database rake tasks don't take into account "username" (PGUSER) for a DB user. They do handle PGHOST, PGPORT and even PGPASSWORD, but for some reason ignore PGUSER.

My usecase: I run "rake db:test:prepare" and see <<psql: FATAL:  password authentication failed for user "pavel">>
