### PR TITLE
Fixed Rails 4 db:migrate broken - undefined method `delete' for NilClass

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/main_adapter.rb
@@ -273,7 +273,7 @@ module ActiveRecord  # :nodoc:
         def add_index(table_name_, column_name_, options_={})
           # FULL REPLACEMENT. RE-CHECK ON NEW VERSIONS.
           # We have to fully-replace because of the gist_clause.
-          options_={} if options_.nil?
+          options_ ||= {}
           gist_clause_ = options_.delete(:spatial) ? ' USING GIST' : ''
           index_name_, index_type_, index_columns_, index_options_ = add_index_options(table_name_, column_name_, options_)
           execute "CREATE #{index_type_} INDEX #{quote_column_name(index_name_)} ON #{quote_table_name(table_name_)}#{gist_clause_} (#{index_columns_})#{index_options_}"


### PR DESCRIPTION
Fixed nil being passed as options_ for def add_index(table_name_, column_name_, options_={})

```
$ rake db:migrate --trace
** Invoke db:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:migrate
==  CreateDeviceLocations: migrating ==========================================
-- create_table(:device_locations)
rake aborted!
An error has occurred, this and all later migrations canceled:

undefined method `delete' for nil:NilClass/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-postgis-adapter-0.6.2/lib/active_record/connection_adapters/postgis_adapter/rails4/main_adapter.rb:276:in `add_index'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/schema_statements.rb:173:in `block in create_table'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/schema_statements.rb:173:in `each_pair'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/schema_statements.rb:173:in `create_table'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-postgis-adapter-0.6.2/lib/active_record/connection_adapters/postgis_adapter/rails4/main_adapter.rb:200:in `create_table'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:595:in `block in method_missing'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:567:in `block in say_with_time'
/Users/ivanfoong/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:567:in `say_with_time'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:587:in `method_missing'
/Users/ivanfoong/Desktop/feedback_parser_rails/db/migrate/20130329152940_create_device_locations.rb:3:in `change'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:541:in `exec_migration'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:525:in `block (2 levels) in migrate'
/Users/ivanfoong/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:524:in `block in migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/connection_pool.rb:302:in `with_connection'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:523:in `migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:666:in `migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:860:in `block (2 levels) in migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:940:in `block in ddl_transaction'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/transactions.rb:209:in `transaction'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:940:in `ddl_transaction'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:859:in `block in migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:855:in `each'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:855:in `migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:711:in `up'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/migration.rb:689:in `migrate'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/activerecord-4.0.0.beta1/lib/active_record/railties/databases.rake:48:in `block (2 levels) in <top (required)>'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:246:in `call'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:246:in `block in execute'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:241:in `each'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:241:in `execute'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:184:in `block in invoke_with_call_chain'
/Users/ivanfoong/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/task.rb:170:in `invoke'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:143:in `invoke_task'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:101:in `block (2 levels) in top_level'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:101:in `each'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:101:in `block in top_level'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:110:in `run_with_threads'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:95:in `top_level'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:73:in `block in run'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/gems/rake-10.0.4/bin/rake:33:in `<top (required)>'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0@global/bin/rake:23:in `load'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0@global/bin/rake:23:in `<main>'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/bin/ruby_noexec_wrapper:14:in `eval'
/Users/ivanfoong/.rvm/gems/ruby-2.0.0-p0/bin/ruby_noexec_wrapper:14:in `<main>'
Tasks: TOP => db:migrate
```
