### PR TITLE
Add missing '=' to db:gis:setup tasks

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
@@ -55,7 +55,7 @@ namespace :db do
       else
         environments_ = [::Rails.env]
         environments_ << 'test' if ::Rails.env.development?
-        configs_ ::ActiveRecord::Base.configurations.values_at(*environments_).compact.reject{ |config_| config_['database'].blank? }
+        configs_ = ::ActiveRecord::Base.configurations.values_at(*environments_).compact.reject{ |config_| config_['database'].blank? }
       end
       configs_.each { |config_| setup_gis(config_) }
     end

--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/databases.rake
@@ -43,7 +43,7 @@ namespace :db do
     task :setup => [:load_config] do
       environments_ = [::Rails.env]
       environments_ << 'test' if ::Rails.env.development?
-      configs_ ::ActiveRecord::Base.configurations.values_at(*environments_).compact.reject{ |config_| config_['database'].blank? }
+      configs_ = ::ActiveRecord::Base.configurations.values_at(*environments_).compact.reject{ |config_| config_['database'].blank? }
       configs_.each do |config_|
         ::ActiveRecord::ConnectionAdapters::PostGISAdapter::PostGISDatabaseTasks.new(config_).setup_gis
       end


### PR DESCRIPTION
Task was throwing 'undefined method `each' for nil:NilClass' at databases.rake:60 under Rails 3.2 due to missing assignment.

Have not tested Rails 4 task.
