### PR TITLE
FIX indexes => trim whitespaces

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
@@ -103,7 +103,7 @@ module ActiveRecord  # :nodoc:
           # Remove postgis from schemas
           schemas_ = schema_search_path.split(/,/)
           schemas_.delete('postgis')
-          schemas_ = schemas_.map{ |p_| quote(p_) }.join(',')
+          schemas_ = schemas_.map{ |p_| quote(p_.strip) }.join(',')
 
           # Get index type by joining with pg_am.
           result_ = query(<<-SQL, name_)


### PR DESCRIPTION
Removing leading and trailing whitespaces for schemas_. The whitespaces causes an empty JOIN for "normal" indexes and therefore remove_index fails.
