### PR TITLE
Create the PostGIS extension unless it already exists

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
@@ -122,9 +122,9 @@ def setup_gis(config_)
       postgis_extension_.each do |extname_|
         if extname_ == 'postgis_topology'
           raise ArgumentError, "'topology' must be in schema_search_path for postgis_topology" unless search_path_.include?('topology')
-          conn_.execute("CREATE EXTENSION #{extname_} SCHEMA topology")
+          conn_.execute("CREATE EXTENSION IF NOT EXISTS #{extname_} SCHEMA topology")
         else
-          conn_.execute("CREATE EXTENSION #{extname_} SCHEMA #{postgis_schema_}")
+          conn_.execute("CREATE EXTENSION IF NOT EXISTS #{extname_} SCHEMA #{postgis_schema_}")
         end
       end
     end

--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
@@ -198,9 +198,9 @@ module ActiveRecord  # :nodoc:
           extension_names.each do |extname_|
             if extname_ == 'postgis_topology'
               raise ::ArgumentError, "'topology' must be in schema_search_path for postgis_topology" unless search_path.include?('topology')
-              connection.execute("CREATE EXTENSION #{extname_} SCHEMA topology")
+              connection.execute("CREATE EXTENSION IF NOT EXISTS #{extname_} SCHEMA topology")
             else
-              connection.execute("CREATE EXTENSION #{extname_} SCHEMA #{postgis_schema}")
+              connection.execute("CREATE EXTENSION IF NOT EXISTS #{extname_} SCHEMA #{postgis_schema}")
             end
           end
         end


### PR DESCRIPTION
If the PostGIS extension is created in the template database (e.g. template1), trying to create the extension again fails. This causes a failure when using `rake db:create`. This is a tiny fix for that issue.
