### PR TITLE
Create language plpgsql

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/postgis_database_tasks.rb
@@ -208,7 +208,7 @@ module ActiveRecord  # :nodoc:
 
         def setup_gis_from_script_dir
           connection.execute("SET search_path TO #{postgis_schema}")
-          connection.execute("CREATE LANGUAGE plpgsql")
+          connection.execute("CREATE OR REPLACE LANGUAGE plpgsql")
           connection.execute(::File.read(::File.expand_path('postgis.sql', script_dir)))
           connection.execute(::File.read(::File.expand_path('spatial_ref_sys.sql', script_dir)))
         end


### PR DESCRIPTION
While creating a Rails application using activerecord-postgis-adapter on FreeBSD, the database creation failed with a complaint about the plpgsql language not being installed.

Creating the plpgsql language indeed fix this issue.  I guess that some configuration may make the plpgsql language available to newly created databases or not. The attached patch is intended to make this work in both situations.
