### PR TITLE
add array coercion

### DIFF
--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -52,6 +52,7 @@
   s_.test_files = ::Dir.glob("test/**/tc_*.rb")
   s_.platform = ::Gem::Platform::RUBY
   s_.add_dependency('rgeo-activerecord', '~> 0.5.0')
+  s_.add_dependency('to_wkt_')
 
   s_.add_development_dependency('rake')
   s_.add_development_dependency('minitest')

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -52,7 +52,7 @@
   s_.test_files = ::Dir.glob("test/**/tc_*.rb")
   s_.platform = ::Gem::Platform::RUBY
   s_.add_dependency('rgeo-activerecord', '~> 0.5.0')
-  s_.add_dependency('to_wkt_')
+  s_.add_dependency('to_wkt_', '~> 0.1.3')
 
   s_.add_development_dependency('rake')
   s_.add_development_dependency('minitest')

--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
@@ -142,7 +142,7 @@ module ActiveRecord  # :nodoc:
               "#{var_name_}, ::ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialColumn::"+
               "FACTORY_SETTINGS_CACHE[#{@factory_settings.object_id}], #{@table_name.inspect}, "+
               "#{name.inspect}, #{@geographic ? 'true' : 'false'}, #{@srid.inspect}, "+
-              "#{@has_z ? 'true' : 'false'}, #{@has_m ? 'true' : 'false'})"
+              "::RGeo::Feature::#{@geometric_type}, #{@has_z ? 'true' : 'false'}, #{@has_m ? 'true' : 'false'})"
           else
             super
           end

--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
@@ -33,6 +33,7 @@
 # -----------------------------------------------------------------------------
 ;
 
+require 'to_wkt_'
 
 module ActiveRecord  # :nodoc:
 
@@ -127,9 +128,8 @@ module ActiveRecord  # :nodoc:
 
         def type_cast(value_)
           if type == :spatial
-            value_ = value_.to_wkt(geometric_type.type_name.underscore.to_sym) if value_.is_a?(Array)
             SpatialColumn.convert_to_geometry(value_, @factory_settings, @table_name, name,
-              @geographic, @srid, @has_z, @has_m)
+              @geographic, @srid, @geometric_type, @has_z, @has_m)
           else
             super
           end
@@ -157,7 +157,9 @@ module ActiveRecord  # :nodoc:
         end
 
 
-        def self.convert_to_geometry(input_, factory_settings_, table_name_, column_, geographic_, srid_, has_z_, has_m_)
+        def self.convert_to_geometry(input_, factory_settings_, table_name_, column_, geographic_, srid_, geometric_type_, has_z_, has_m_)
+          input_ = input_.to_wkt(geometric_type_.type_name.underscore.to_sym) if input_.is_a?(Array)
+
           if srid_
             constraints_ = {:geographic => geographic_, :has_z_coordinate => has_z_,
               :has_m_coordinate => has_m_, :srid => srid_}

--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
@@ -157,6 +157,7 @@ module ActiveRecord  # :nodoc:
 
 
         def self.convert_to_geometry(input_, factory_settings_, table_name_, column_, geographic_, srid_, has_z_, has_m_)
+          input_ = "POINT(#{input_[0]} #{input_[1]})" if (input_.is_a?(Array) && input_.count == 2)
           if srid_
             constraints_ = {:geographic => geographic_, :has_z_coordinate => has_z_,
               :has_m_coordinate => has_m_, :srid => srid_}

--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/spatial_column.rb
@@ -127,6 +127,7 @@ module ActiveRecord  # :nodoc:
 
         def type_cast(value_)
           if type == :spatial
+            value_ = value_.to_wkt(geometric_type.type_name.underscore.to_sym) if value_.is_a?(Array)
             SpatialColumn.convert_to_geometry(value_, @factory_settings, @table_name, name,
               @geographic, @srid, @has_z, @has_m)
           else
@@ -157,7 +158,6 @@ module ActiveRecord  # :nodoc:
 
 
         def self.convert_to_geometry(input_, factory_settings_, table_name_, column_, geographic_, srid_, has_z_, has_m_)
-          input_ = "POINT(#{input_[0]} #{input_[1]})" if (input_.is_a?(Array) && input_.count == 2)
           if srid_
             constraints_ = {:geographic => geographic_, :has_z_coordinate => has_z_,
               :has_m_coordinate => has_m_, :srid => srid_}

--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/spatial_column.rb
@@ -33,6 +33,7 @@
 # -----------------------------------------------------------------------------
 ;
 
+require 'to_wkt_'
 
 module ActiveRecord  # :nodoc:
 
@@ -124,7 +125,7 @@ module ActiveRecord  # :nodoc:
         def type_cast(value_)
           if spatial?
             SpatialColumn.convert_to_geometry(value_, @factory_settings, @table_name, name,
-              @geographic, @srid, @has_z, @has_m)
+              @geographic, @srid, @geometric_type, @has_z, @has_m)
           else
             super
           end
@@ -139,7 +140,9 @@ module ActiveRecord  # :nodoc:
         end
 
 
-        def self.convert_to_geometry(input_, factory_settings_, table_name_, column_, geographic_, srid_, has_z_, has_m_)
+        def self.convert_to_geometry(input_, factory_settings_, table_name_, column_, geographic_, srid_, geometric_type_, has_z_, has_m_)
+          input_ = input_.to_wkt(geometric_type_.type_name.underscore.to_sym) if input_.is_a?(Array)
+
           if srid_
             constraints_ = {:geographic => geographic_, :has_z_coordinate => has_z_,
               :has_m_coordinate => has_m_, :srid => srid_}

--- a/test/tc_basic.rb
+++ b/test/tc_basic.rb
@@ -35,6 +35,7 @@
 
 require 'minitest/autorun'
 require 'rgeo/active_record/adapter_test_helper'
+require 'to_wkt_'
 
 
 module RGeo
@@ -61,6 +62,10 @@ module RGeo
               when :latlon_point_geographic
                 klass_.connection.create_table(:spatial_test) do |t_|
                   t_.column 'latlon', :point, :srid => 4326, :geographic => true
+                end
+              when :line_string
+                klass_.connection.create_table(:spatial_test) do |t_|
+                  t_.column 'line', :line_string, :srid => 4326, :geographic => true
                 end
               when :no_constraints
                 klass_.connection.create_table(:spatial_test) do |t_|
@@ -165,6 +170,22 @@ module RGeo
               assert_equal(@geographic_factory.point(1.0, 2.0), obj2_.latlon)
               assert_equal(4326, obj2_.latlon.srid)
               assert_equal(false, ::RGeo::Geos.is_geos?(obj2_.latlon))
+            end
+
+            def test_set_line_string_from_array
+              klass_ = populate_ar_class(:line_string)
+              obj_ = klass_.new
+              line_array = [ [1.0, 1.0], [2.0, 2.0], [3.0, 3.0] ]
+              points = line_array.map{ |a| @geographic_factory.point(*a) }
+              line_string = @geographic_factory.line_string(points)
+              obj_.line = line_array
+              obj_.save!
+              id_ = obj_.id
+              obj2_ = klass_.find(id_)
+
+              assert_equal(obj2_.line, line_string)
+              assert_equal(4326, obj2_.line.srid)
+              assert_equal(false, ::RGeo::Geos.is_geos?(obj2_.line))
             end
 
             def test_custom_factory

--- a/test/tc_basic.rb
+++ b/test/tc_basic.rb
@@ -155,6 +155,17 @@ module RGeo
               end
             end
 
+            def test_set_point_from_array
+              klass_ = populate_ar_class(:latlon_point_geographic)
+              obj_ = klass_.new
+              obj_.latlon = [1.0, 2.0]
+              obj_.save!
+              id_ = obj_.id
+              obj2_ = klass_.find(id_)
+              assert_equal(@geographic_factory.point(1.0, 2.0), obj2_.latlon)
+              assert_equal(4326, obj2_.latlon.srid)
+              assert_equal(false, ::RGeo::Geos.is_geos?(obj2_.latlon))
+            end
 
             def test_custom_factory
               klass_ = create_ar_class


### PR DESCRIPTION
This PR adds support for array coercion/casting for spatial columns in ActiveRecord using activerecord-postgis-adapter leveraging [to_wkt_](http://rubygems.org/gems/to_wkt_).

This update allows for something like:

```ruby
foo.lonlat = [42, -42]
```

Under the hood, it's looking if the column is `:spatial` and if the value coming in, to be cast, is an array.  If it is, it converts the array into WKT and proceeds as usual.

The code has been updated for compatibility with AR3 and AR4 and is passing all of the tests there were passing previously off of your current master.