### PR TITLE
use the right type_map

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/main_adapter.rb
@@ -144,9 +144,9 @@ module ActiveRecord  # :nodoc:
         end
 
 
-        def create_table_definition(name_, temporary_, options_)
+        def create_table_definition(name_, temporary_, options_, as_=nil)
           # Override to create a spatial table definition (post-4.0.0.beta1)
-          PostGISAdapter::TableDefinition.new(native_database_types, name_, temporary_, options_, self)
+          PostGISAdapter::TableDefinition.new(native_database_types, name_, temporary_, options_, as_, self)
         end
 
 

--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/spatial_table_definition.rb
@@ -43,10 +43,10 @@ module ActiveRecord  # :nodoc:
 
       class TableDefinition < ConnectionAdapters::PostgreSQLAdapter::TableDefinition  # :nodoc:
 
-        def initialize(types_, name_, temporary_, options_, base_)
+        def initialize(types_, name_, temporary_, options_, as_, base_)
           @base = base_
           @spatial_columns_hash = {}
-          super(types_, name_, temporary_, options_)
+          super(types_, name_, temporary_, options_, as_)
         end
 
         def column(name_, type_, options_={})


### PR DESCRIPTION
Rails 4.1 removed the `TYPE_MAP` constant. This fix follows that change but still works on Rails 4.0.
