### PR TITLE
Rails 4

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails4/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails4/spatial_column.rb
@@ -40,6 +40,12 @@ module ActiveRecord  # :nodoc:
 
     module PostGISAdapter  # :nodoc:
 
+      # a hack. Active record is still instantiating the column as this type. it then calls spatial? on that column 
+      class ConnectionAdapters::PostgreSQLColumn  # :nodoc:
+        def spatial?
+          type == :spatial || type == :geography
+        end
+      end 
 
       class SpatialColumn < ConnectionAdapters::PostgreSQLColumn  # :nodoc:
 
@@ -106,9 +112,6 @@ module ActiveRecord  # :nodoc:
         alias_method :has_m?, :has_m
 
 
-        def spatial?
-          type == :spatial || type == :geography
-        end
 
 
         def has_spatial_constraints?


### PR DESCRIPTION
Rails 4.1.0.beta1
PostGis 1.5

issue:
when instantiating an active record object, ActiveRecord tries to create a plain old ConnectionAdapters::PostgreSQLColumn, rather than a SpatialColumn. 

Since ConnectionAdapters::PostgreSQLColumn lacks the method :spatial? , it fails.

this small hack fixes the problem for me. 

It would seem the plan would be for ActiveRecord to create a spatial column when necessary. In any case case, it seems :spatial? should not live in the class called Spatial

sorry if I'm misunderstanding the plan here; I'm not very familiar with this codebase. 
