### PR TITLE
Add migration status to the sql structure dump

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/databases.rake
@@ -206,6 +206,10 @@ end
   search_path_ = search_path_.map{ |sp_| "--schema=#{sp_}" }.join(" ")
   `pg_dump -i -U "#{config_["username"]}" -s -x -O -f #{filename_} #{search_path_} #{config_["database"]}`
   raise "Error dumping database" if $?.exitstatus == 1
+
+  if ActiveRecord::Base.connection.supports_migrations?
+    File.open(filename_, "a") { |f| f << ActiveRecord::Base.connection.dump_schema_information }
+  end
 end
 
 


### PR DESCRIPTION
This adds functionality introduced by Rails upstream.  For structure dumping, it appends the data of the `schema_migrations` table or equivalent into `#{Rails.env}_structure.sql` file so that when tasks like `rake db:reset` or `rake db:setup` are used, the migration state is kept in the database.
