### PR TITLE
Add Rails 4 compatibility under JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - jruby-19mode
   - rbx-2
 env:
   - POSTGIS=2.0

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pg', '~> 0.17', platform: :ruby
-gem 'byebug', platform: :ruby
+gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.9', platform: :jruby
+gem 'ffi-geos', platform: :jruby
+gem 'byebug', platform: [:ruby_20, :ruby_21]

--- a/lib/active_record/connection_adapters/postgis_adapter/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/arel_tosql.rb
@@ -1,7 +1,13 @@
 module Arel  # :nodoc:
   module Visitors  # :nodoc:
+    # Different super-class under JRuby JDBC adapter.
+    PostGISSuperclass = if defined?(::ArJdbc::PostgreSQL::BindSubstitution)
+      ::ArJdbc::PostgreSQL::BindSubstitution
+    else
+      ::Arel::Visitors::PostgreSQL
+    end
 
-    class PostGIS < PostgreSQL  # :nodoc:
+    class PostGIS < PostGISSuperclass  # :nodoc:
 
       FUNC_MAP = {
         'st_wkttosql' => 'ST_GeomFromEWKT',

--- a/lib/active_record/connection_adapters/postgis_adapter/create_connection.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/create_connection.rb
@@ -1,26 +1,37 @@
-require 'pg'
+if(defined?(::RUBY_ENGINE) && ::RUBY_ENGINE == 'jruby')
+  require 'active_record/connection_adapters/jdbcpostgresql_adapter'
+else
+  require 'pg'
+end
 
 module ActiveRecord  # :nodoc:
   module ConnectionHandling  # :nodoc:
+    if(defined?(::RUBY_ENGINE) && ::RUBY_ENGINE == 'jruby')
+      def postgis_connection(config)
+        config[:adapter_class] = ::ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter
+        postgresql_connection(config)
+      end
+      alias_method :jdbcpostgis_connection, :postgis_connection
+    else
+      # Based on the default <tt>postgresql_connection</tt> definition from ActiveRecord.
+      # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+      def postgis_connection(config)
+        # FULL REPLACEMENT because we need to create a different class.
+        conn_params = config.symbolize_keys
 
-    # Based on the default <tt>postgresql_connection</tt> definition from ActiveRecord.
-    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
-    def postgis_connection(config)
-      # FULL REPLACEMENT because we need to create a different class.
-      conn_params = config.symbolize_keys
+        conn_params.delete_if { |_, v| v.nil? }
 
-      conn_params.delete_if { |_, v| v.nil? }
+        # Map ActiveRecords param names to PGs.
+        conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
+        conn_params[:dbname] = conn_params.delete(:database) if conn_params[:database]
 
-      # Map ActiveRecords param names to PGs.
-      conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
-      conn_params[:dbname] = conn_params.delete(:database) if conn_params[:database]
+        # Forward only valid config params to PGconn.connect.
+        conn_params.keep_if { |k, _| VALID_CONN_PARAMS.include?(k) }
 
-      # Forward only valid config params to PGconn.connect.
-      conn_params.keep_if { |k, _| VALID_CONN_PARAMS.include?(k) }
-
-      # The postgres drivers don't allow the creation of an unconnected PGconn object,
-      # so just pass a nil connection object for the time being.
-      ::ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter.new(nil, logger, conn_params, config)
+        # The postgres drivers don't allow the creation of an unconnected PGconn object,
+        # so just pass a nil connection object for the time being.
+        ::ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter.new(nil, logger, conn_params, config)
+      end
     end
 
   end

--- a/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
@@ -34,6 +34,12 @@ module ActiveRecord  # :nodoc:
           column_info = SpatialColumnInfo.new(self, quote_string(table_name.to_s))
           # Limit, precision, and scale are all handled by the superclass.
           column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod|
+            # JDBC gets true/false in Rails 4, where other platforms get
+            # 't'/'f' strings.
+            if(notnull.is_a?(String))
+              notnull = (notnull == 't')
+            end
+
             oid = column_type_map.fetch(oid.to_i, fmod.to_i) { OID::Identity.new }
             SpatialColumn.new(@rgeo_factory_settings,
                               table_name,
@@ -41,7 +47,7 @@ module ActiveRecord  # :nodoc:
                               default,
                               oid,
                               type,
-                              notnull == 'f',
+                              !notnull,
                               column_info.get(column_name, type))
           end
         end

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -247,6 +247,52 @@ class DDLTest < ActiveSupport::TestCase  # :nodoc:
       assert_nil klass.columns[1].has_z
     end
 
+    # Ensure that null contraints info is getting captured like the
+    # normal adapter.
+    def test_null_constraints
+      klass_ = create_ar_class
+      klass_.connection.create_table(:spatial_test) do |t_|
+        t_.column 'nulls_allowed', :string, :null => true
+        t_.column 'nulls_disallowed', :string, :null => false
+      end
+      assert_equal(true, klass_.columns[-2].null)
+      assert_equal(false, klass_.columns[-1].null)
+    end
+
+    # Ensure that default value info is getting captured like the
+    # normal adapter.
+    def test_column_defaults
+      klass_ = create_ar_class
+      klass_.connection.create_table(:spatial_test) do |t_|
+        t_.column 'sample_integer_neg_default', :integer, :default => -1
+      end
+      assert_equal(-1, klass_.columns.last.default)
+    end
+
+    # Ensure that column type info is getting captured like the
+    # normal adapter.
+    def test_column_types
+      klass_ = create_ar_class
+      klass_.connection.create_table(:spatial_test) do |t_|
+        t_.column 'sample_integer', :integer
+        t_.column 'sample_string', :string
+        t_.column 'latlon', :point
+      end
+      assert_equal(:integer, klass_.columns[-3].type)
+      assert_equal(:string, klass_.columns[-2].type)
+      assert_equal(:spatial, klass_.columns[-1].type)
+    end
+
+    def test_array_columns
+      klass_ = create_ar_class
+      klass_.connection.create_table(:spatial_test) do |t_|
+        t_.column 'sample_array', :string, :array => true
+        t_.column 'sample_non_array', :string
+      end
+      assert_equal(true, klass_.columns[-2].array)
+      assert_equal(false, klass_.columns[-1].array)
+    end
+
     private
 
     def geometry_column_count_query

--- a/travis/ar40.gemfile
+++ b/travis/ar40.gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-gem "pg", "~> 0.17"
+gem "pg", "~> 0.17", :platform => :ruby
+gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.9", :platform => :jruby
+gem "ffi-geos", :platform => :jruby
 gem "activerecord", '~> 4.0.5'
 
 gemspec :path => "../"

--- a/travis/ar41.gemfile
+++ b/travis/ar41.gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-gem "pg", "~> 0.17"
+gem "pg", "~> 0.17", :platform => :ruby
+gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.9", :platform => :jruby
+gem "ffi-geos", :platform => :jruby
 gem "activerecord", '~> 4.1.0'
 
 gemspec :path => "../"


### PR DESCRIPTION
This adds Rails 4 compatibility under JRuby and the activerecord-jdbc-adapter. This addresses https://github.com/dazuma/activerecord-postgis-adapter/issues/76. Fixing this mostly involved making the adapter skip the OID usage stuff, since the jdbc adapter doesn't utilize that.

This also fixes an issue I discovered while running the test suite: Rails 3.1 compatibility was broken under JRuby if you were using the activerecord-jdbc-adapter 1.3.x (but it still worked fine under 1.2.x). I'm not sure how many people are actually using this likely obscure combination of versions, but the fix was relatively straightforward, so I fixed that too.

Note that the Rails 4 tests will currently fail on Travis due to this rgeo-activerecord issue: https://github.com/dazuma/rgeo-activerecord/pull/12 But that issues affects all ruby platforms under Rails 4, not just JRuby. So I don't think you'll get clean tests until that issue is addressed in rgeo-activerecord, but in my own local testing, I get clean tests when building against that rgeo-activerecord branch.
