### PR TITLE
Remove implementation of no_constraints in main_adapter

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
@@ -116,9 +116,7 @@ module ActiveRecord  # :nodoc:
             has_z = col.has_z?
             has_m = col.has_m?
             type = "#{type}M" if has_m && !has_z
-            dimensions_ = 2
-            dimensions_ += 1 if has_z
-            dimensions_ += 1 if has_m
+            dimensions_ = set_dimensions(has_m, has_z)
             execute("SELECT AddGeometryColumn('#{quote_string(table_name)}', '#{quote_string(col.name.to_s)}', #{col.srid}, '#{quote_string(type)}', #{dimensions_})")
           end
         end
@@ -127,32 +125,7 @@ module ActiveRecord  # :nodoc:
           table_name = table_name.to_s
           column_name = column_name.to_s
           if (info = spatial_column_constructor(type.to_sym))
-            limit = options[:limit]
-            if type.to_s == 'geometry' &&
-              (options[:no_constraints] || limit.is_a?(::Hash) && limit[:no_constraints])
-            then
-              options.delete(:limit)
-              super
-            else
-              options.merge!(limit) if limit.is_a?(::Hash)
-              type = (options[:type] || info[:type] || type).to_s.gsub('_', '').upcase
-              has_z = options[:has_z]
-              has_m = options[:has_m]
-              srid = (options[:srid] || PostGISAdapter::DEFAULT_SRID).to_i
-              if options[:geographic]
-                type << 'Z' if has_z
-                type << 'M' if has_m
-                execute("ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{quote_column_name(column_name)} GEOGRAPHY(#{type},#{srid})")
-                change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
-                change_column_null(table_name, column_name, false, options[:default]) if options[:null] == false
-              else
-                type = "#{type}M" if has_m && !has_z
-                dimensions = 2
-                dimensions += 1 if has_z
-                dimensions += 1 if has_m
-                execute("SELECT AddGeometryColumn('#{quote_string(table_name)}', '#{quote_string(column_name)}', #{srid}, '#{quote_string(type)}', #{dimensions})")
-              end
-            end
+            add_spatial_column(column_name, table_name, info, type, options)
           else
             super
           end
@@ -204,12 +177,39 @@ module ActiveRecord  # :nodoc:
 
         private
 
+        def add_spatial_column(column_name, table_name, info, type, options)
+          limit = options[:limit]
+          options.merge!(limit) if limit.is_a?(::Hash)
+          type = (options[:type] || info[:type] || type).to_s.gsub('_', '').upcase
+          has_z = options[:has_z]
+          has_m = options[:has_m]
+          srid = (options[:srid] || PostGISAdapter::DEFAULT_SRID).to_i
+          if options[:geographic]
+            type << 'Z' if has_z
+            type << 'M' if has_m
+            execute("ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{quote_column_name(column_name)} GEOGRAPHY(#{type},#{srid})")
+            change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
+            change_column_null(table_name, column_name, false, options[:default]) if options[:null] == false
+          else
+            type = "#{type}M" if has_m && !has_z
+            dimensions = set_dimensions(has_m, has_z)
+            execute("SELECT AddGeometryColumn('#{quote_string(table_name)}', '#{quote_string(column_name)}', #{srid}, '#{quote_string(type)}', #{dimensions})")
+          end
+        end
+
         def column_type_map
           if defined?(type_map) # ActiveRecord 4.1+
             type_map
           else # ActiveRecord 4.0.x
             OID::TYPE_MAP
           end
+        end
+
+        def set_dimensions(has_m, has_z)
+          dimensions = 2
+          dimensions += 1 if has_z
+          dimensions += 1 if has_m
+          dimensions
         end
 
       end

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -27,23 +27,6 @@ module RGeo
               assert_equal(0, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
             end
 
-            # no_constraints no longer supported in PostGIS 2.0
-            def _test_create_no_constraints_geometry
-              klass = create_ar_class
-              klass.connection.create_table(:spatial_test) do |t|
-                t.column 'geom', :geometry, :limit => {:no_constraints => true}
-              end
-              assert_equal(0, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
-              col = klass.columns.last
-              assert_equal(::RGeo::Feature::Geometry, col.geometric_type)
-              assert_equal(false, col.geographic?)
-              assert_equal(false, col.has_spatial_constraints?)
-              assert_nil(col.srid)
-              assert(klass.cached_attributes.include?('geom'))
-              klass.connection.drop_table(:spatial_test)
-              assert_equal(0, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
-            end
-
             def test_create_simple_geography
               klass = create_ar_class
               klass.connection.create_table(:spatial_test) do |t|
@@ -96,29 +79,6 @@ module RGeo
               assert_equal(4326, cols_[-2].srid)
               assert_equal(false, cols_[-2].geographic?)
               assert_equal(true, cols_[-2].has_spatial_constraints?)
-              assert_nil(cols_[-1].geometric_type)
-              assert_equal(false, cols_[-1].has_spatial_constraints?)
-            end
-
-            # no_constraints no longer supported in PostGIS 2.0
-            def _test_add_no_constraints_geometry_column
-              klass = create_ar_class
-              klass.connection.create_table(:spatial_test) do |t|
-                t.column('latlon', :geometry)
-              end
-              klass.connection.change_table(:spatial_test) do |t|
-                t.column('geom2', :geometry, :no_constraints => true)
-                t.column('name', :string)
-              end
-              assert_equal(1, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
-              cols_ = klass.columns
-              assert_equal(::RGeo::Feature::Geometry, cols_[-3].geometric_type)
-              assert_equal(0, cols_[-3].srid)
-              assert_equal(true, cols_[-3].has_spatial_constraints?)
-              assert_equal(::RGeo::Feature::Geometry, cols_[-2].geometric_type)
-              assert_nil(cols_[-2].srid)
-              assert_equal(false, cols_[-2].geographic?)
-              assert_equal(false, cols_[-2].has_spatial_constraints?)
               assert_nil(cols_[-1].geometric_type)
               assert_equal(false, cols_[-1].has_spatial_constraints?)
             end
@@ -193,22 +153,6 @@ module RGeo
               assert_equal(false, col.geographic?)
               assert_equal(0, col.srid)
               assert(klass.cached_attributes.include?('latlon'))
-              klass.connection.drop_table(:spatial_test)
-              assert_equal(0, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
-            end
-
-            # no_constraints no longer supported in PostGIS 2.0
-            def _test_create_no_constraints_geometry_using_shortcut
-              klass = create_ar_class
-              klass.connection.create_table(:spatial_test) do |t|
-                t.spatial 'geom', :no_constraints => true
-              end
-              assert_equal(0, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
-              col = klass.columns.last
-              assert_equal(::RGeo::Feature::Geometry, col.geometric_type)
-              assert_equal(false, col.geographic?)
-              assert_nil(col.srid)
-              assert(klass.cached_attributes.include?('geom'))
               klass.connection.drop_table(:spatial_test)
               assert_equal(0, klass.connection.select_value("SELECT COUNT(*) FROM geometry_columns WHERE f_table_name='spatial_test'").to_i)
             end


### PR DESCRIPTION
This pull request removes the implementation of `no_constraints` in `main_adapter`.  This is potentially a non-backwards compatible change but the functionality is not being tested for as is (the tests were skipped) so it seems prudent to remove the implementation as well as the tests.  The other changes are refactorings that do not affect the class' behavior.
- Remove skipped tests in `test/ddl_test.rb` that test now unsupported
  (as of PostGIS 2.0) `no_constraints`
- Remove implementation of `no_constraints` in `main_adapter`
- Create private `set_dimensions` method in `main_adapter`
- Refactor `main_adapter#add_column` method to use private
  `add_spatial_column` method

I'm using this gem on a project and am getting up to speed so I can contribute.  Thanks.
