### PR TITLE
Fix "allow_failures" syntax for travis to allow Rubinius failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ env:
 gemfile:
   - travis/ar40.gemfile
   - travis/ar41.gemfile
-allow_failures:
-  - rbx-2
 matrix:
-  exclude:
+  allow_failures:
+    - rvm: rbx-2
 before_install: ./travis/before_install.sh
 before_script: ./travis/before_script.sh
 script: bundle exec rake test


### PR DESCRIPTION
The `allow_failures` block was misplaced in the `.travis.yml`. file, so builds were failing when the Rubinius build was broken. Rubinius seems to be broken across the board right now due to this Travis issue: https://github.com/travis-ci/travis-ci/issues/2542

This fixes it so rubinius failures are allowed without breaking the build (which I believe is what was intended before). However, if you do want ensure Rubinius is passing, then you'll obviously want to remove this block altogether (and wait for Travis to Rubinius issue on their end).
