### PR TITLE
Renames OID::Spatial#binary to #binary_string? -- Fixes #164

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/oid/spatial.rb
@@ -100,12 +100,12 @@ module ActiveRecord
             nil
           end
 
-          def binary?(string)
+          def binary_string?(string)
             string[0] == "\x00" || string[0] == "\x01" || string[0, 4] =~ /[0-9a-fA-F]{4}/
           end
 
           def wkt_parser(factory, string)
-            if binary?(string)
+            if binary_string?(string)
               RGeo::WKRep::WKBParser.new(factory, support_ewkb: true, default_srid: @srid)
             else
               RGeo::WKRep::WKTParser.new(factory, support_ewkt: true, default_srid: @srid)


### PR DESCRIPTION
Renaming the method solves the issue of the method being called by ActiveRecord's LogSubscriber, which expects `OID::Spatial` to inherit or overwrite the `binary?` method of ActiveRecord's `Type::Value`.

If ActiveRecord called the method before this change a NoMethodError was thrown, since the `binary?` method was private.

This change renames the method since it's for internal use only.

---

Please see #164 for more details.

What do you think? Is the name okay? Or did I misunderstand the part about `binary?(string)` being used for internal use only?