### PR TITLE
Allow dumped schema to be reloaded

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
@@ -44,12 +44,19 @@ module ActiveRecord  # :nodoc:
                     :geometric_type,
                     :has_m,
                     :has_z,
-                    :limit, # override
                     :srid
 
         alias :geographic? :geographic
         alias :has_z? :has_z
         alias :has_m? :has_m
+
+        def limit
+          if spatial?
+            @limit
+          else
+            super
+          end
+        end
 
         def spatial?
           cast_type.respond_to?(:spatial?) && cast_type.spatial?

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_table_definition.rb
@@ -12,14 +12,15 @@ module ActiveRecord  # :nodoc:
         # super: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L320
         def new_column_definition(name, type, options)
           if (info = MainAdapter.spatial_column_options(type.to_sym))
+            if (limit = options.delete(:limit))
+              options.merge!(limit) if limit.is_a?(::Hash)
+            end
+
             geo_type = ColumnDefinition.geo_type(options[:type] || type || info[:type])
             base_type = info[:type] || (options[:geographic] ? :geography : :geometry)
 
             # puts name.dup << " - " << type.to_s << " - " << options.to_s << " :: " << geo_type.to_s << " - " << base_type.to_s
 
-            if (limit = options.delete(:limit))
-              options.merge!(limit) if limit.is_a?(::Hash)
-            end
             if options[:geographic]
               options[:limit] = ColumnDefinition.options_to_limit(geo_type, options)
             end

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -270,6 +270,15 @@ class DDLTest < ActiveSupport::TestCase  # :nodoc:
     assert_equal false, klass.columns[-1].array
   end
 
+  def test_non_spatial_column_limits
+    klass.connection.create_table(:spatial_models, force: true) do |t|
+      t.string :foo, limit: 123
+    end
+    klass.reset_column_information
+    col = klass.columns.last
+    assert_equal 123, col.limit
+  end
+
   private
 
   def klass

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -270,6 +270,15 @@ class DDLTest < ActiveSupport::TestCase  # :nodoc:
     assert_equal false, klass.columns[-1].array
   end
 
+  def test_reload_dumped_schema
+    klass.connection.create_table(:spatial_models, force: true) do |t|
+      t.geography "latlon1", limit: {:srid=>4326, :type=>"point", :geographic=>true}
+    end
+    klass.reset_column_information
+    col = klass.columns.last
+    assert_equal 4326, col.srid
+  end
+
   def test_non_spatial_column_limits
     klass.connection.create_table(:spatial_models, force: true) do |t|
       t.string :foo, limit: 123


### PR DESCRIPTION
Fixes #161 and #167

Rather than the approach suggested in #161, I've made a small change that allows the dumped schema to be loaded.  ~~Not familiar enough with the codebase to write a proper test for this; can someone help out?~~ EDIT: I've added tests for both #161 and #167

Example schema.rb:

```ruby
  create_table "poo", id: false, force: :cascade do |t|
    t.geography "blah", limit: {:srid=>4326, :type=>"point", :geographic=>true}
  end
```

`rake db:test:prepare` previously blew up on this schema, but works correctly now.