### PR TITLE
Add optional coordinates (z,m) for spherical_factory

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/oid/spatial.rb
@@ -11,7 +11,12 @@ module ActiveRecord
           #   "geometry(Geography,4326)"
           def initialize(oid, sql_type)
             @geo_type, @srid, @has_z, @has_m = self.class.parse_sql_type(sql_type)
-            @factory_generator = RGeo::Geographic.spherical_factory(srid: 4326) if oid =~ /geography/
+            if oid =~ /geography/
+              factory_opts = {srid: (@srid || 4326)}
+              factory_opts[:has_z_coordinate] = @has_z
+              factory_opts[:has_m_coordinate] = @has_m
+              @factory_generator = RGeo::Geographic.spherical_factory(factory_opts)
+            end
           end
 
           # sql_type: geometry, geometry(Point), geometry(Point,4326), ...


### PR DESCRIPTION
Add optional coordinates (z,m) for spherical_factory when Spatial value initializing. 