### PR TITLE
Column specific factory settings are ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,50 +288,29 @@ database has an integer type, ActiveRecord automatically casts the data to a
 Ruby Integer. In the same way, the activerecord-postgis-adapter automatically
 casts spatial data to a corresponding RGeo data type.
 
-However, RGeo offers more "flexibility" in its type system than can be
+RGeo offers more flexibility in its type system than can be
 interpreted solely from analyzing the database column. For example, you can
 configure RGeo objects to exhibit certain behaviors related to their
 serialization, validation, coordinate system, or computation. These settings
-are embodied in the RGeo "factory" associated with the object.
+are embodied in the RGeo factory associated with the object.
 
-Therefore, you can configure the adapter to use a particular factory (i.e. a
-particular combination of settings) for data associated with each column in
-the database. This is done by calling class methods on the ActiveRecord class
-associated with that database table. Specifically, you can call
-`set_rgeo_factory_for_column` to set the factory that ActiveRecord uses for a
-particular column.
-
-You can also provide a "factory generator" function which takes information
-from the database column and returns a suitable factory. Set the factory
-generator by setting the `rgeo_factory_generator` class attribute of your
-ActiveRecord class. The generator should be a callable object that takes a
-hash that could include the following keys:
-
-*   `:srid` -- the SRID of the database column
-*   `:has_z_coordinate` -- true if the database column has a Z coordinate
-*   `:has_m_coordinate` -- true if the database column has a M coordinate
-*   `:geographic` -- true if the database column is geographic instead of
-    geometric
-
+You can configure the adapter to use a particular factory (i.e. a
+particular combination of settings) for data associated with each type in
+the database.
 
 Here are some examples, given the spatial table defined above:
 
 ```ruby
-class MySpatialTable < ActiveRecord::Base
+# on application setup. For example, in an initializer:
 
+RGeo::ActiveRecord::PostGISAdapter::SpatialFactoryStore.instance.tap do |config|
   # By default, use the GEOS implementation for spatial columns.
-  self.rgeo_factory_generator = RGeo::Geos.factory_generator
+  config.default = RGeo::Geos.factory_generator
 
-  # But use a geographic implementation for the :lonlat column.
-  set_rgeo_factory_for_column(:lonlat, RGeo::Geographic.spherical_factory(:srid => 4326))
-
+  # But use a geographic implementation for point columns.
+  config.register(RGeo::Geographic.spherical_factory(srid: 4326), geo_type: "point")
 end
 ```
-
-The `rgeo_factory_generator` attribute and `set_rgeo_factory_for_column`
-method are actually implemented (and documented) in the "rgeo-activerecord"
-gem, which is a dependency of the activerecord-postgis-adapter.
-
 
 ## Working With Spatial Data
 

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -6,6 +6,7 @@
 require 'active_record/connection_adapters/postgresql_adapter'
 require 'rgeo/active_record'
 require 'active_record/connection_adapters/postgis_adapter/version'
+require 'active_record/connection_adapters/postgis_adapter/spatial_factory_store'
 require 'active_record/connection_adapters/postgis_adapter/schema_statements'
 require 'active_record/connection_adapters/postgis_adapter/main_adapter'
 require 'active_record/connection_adapters/postgis_adapter/spatial_column_info'

--- a/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/main_adapter.rb
@@ -30,10 +30,6 @@ module ActiveRecord  # :nodoc:
         #   PostGISAdapter::SchemaCreation.new self
         # end
 
-        def set_rgeo_factory_settings(factory_settings)
-          @rgeo_factory_settings = factory_settings
-        end
-
         def adapter_name
           "PostGIS".freeze
         end

--- a/lib/active_record/connection_adapters/postgis_adapter/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/oid/spatial.rb
@@ -10,13 +10,8 @@ module ActiveRecord
           #   "geometry(Polygon,4326) NOT NULL"
           #   "geometry(Geography,4326)"
           def initialize(oid, sql_type)
+            @sql_type = sql_type
             @geo_type, @srid, @has_z, @has_m = self.class.parse_sql_type(sql_type)
-            if oid =~ /geography/
-              factory_opts = {srid: (@srid || 4326)}
-              factory_opts[:has_z_coordinate] = @has_z
-              factory_opts[:has_m_coordinate] = @has_m
-              @factory_generator = RGeo::Geographic.spherical_factory(factory_opts)
-            end
           end
 
           # sql_type: geometry, geometry(Point), geometry(Point,4326), ...
@@ -52,12 +47,19 @@ module ActiveRecord
             [geo_type, srid, has_z, has_m]
           end
 
-          def factory_generator
-            @factory_generator
+          def spatial_factory
+            @spatial_factory ||=
+              SpatialFactoryStore.instance.factory(
+                geo_type: @geo_type,
+                has_m:    @has_m,
+                has_z:    @has_z,
+                sql_type: @sql_type,
+                srid:     @srid,
+              )
           end
 
           def geographic?
-            !!factory_generator
+            @sql_type =~ /geography/
           end
 
           def spatial?
@@ -90,16 +92,14 @@ module ActiveRecord
 
           def cast_value(value)
             return if value.nil?
-            RGeo::WKRep::WKBParser.new(@factory_generator, support_ewkb: true).parse(value)
+            RGeo::WKRep::WKBParser.new(spatial_factory, support_ewkb: true).parse(value)
           rescue RGeo::Error::ParseError
             nil
           end
 
           # convert WKT string into RGeo object
           def parse_wkt(string)
-            # factory = factory_settings.get_column_factory(table_name, column, constraints)
-            factory = @factory_generator || RGeo::ActiveRecord::RGeoFactorySettings.new
-            wkt_parser(factory, string).parse(string)
+            wkt_parser(string).parse(string)
           rescue RGeo::Error::ParseError
             nil
           end
@@ -108,14 +108,13 @@ module ActiveRecord
             string[0] == "\x00" || string[0] == "\x01" || string[0, 4] =~ /[0-9a-fA-F]{4}/
           end
 
-          def wkt_parser(factory, string)
+          def wkt_parser(string)
             if binary_string?(string)
-              RGeo::WKRep::WKBParser.new(factory, support_ewkb: true, default_srid: @srid)
+              RGeo::WKRep::WKBParser.new(spatial_factory, support_ewkb: true, default_srid: @srid)
             else
-              RGeo::WKRep::WKTParser.new(factory, support_ewkt: true, default_srid: @srid)
+              RGeo::WKRep::WKTParser.new(spatial_factory, support_ewkt: true, default_srid: @srid)
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/postgis_adapter/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/schema_statements.rb
@@ -23,8 +23,7 @@ module ActiveRecord
 
           column_info = spatial_column_info(table_name).get(column_name, sql_type)
 
-          SpatialColumn.new(@rgeo_factory_settings,
-                            table_name,
+          SpatialColumn.new(table_name,
                             column_name,
                             default,
                             cast_type,

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_column.rb
@@ -9,8 +9,7 @@ module ActiveRecord  # :nodoc:
         # cast_type example classes:
         #   OID::Spatial
         #   OID::Integer
-        def initialize(factory_settings, table_name, name, default, cast_type, sql_type = nil, null = true, default_function = nil, opts = nil)
-          @factory_settings = factory_settings
+        def initialize(table_name, name, default, cast_type, sql_type = nil, null = true, default_function = nil, opts = nil)
           @table_name = table_name
           @geographic = !!(sql_type =~ /geography\(/i)
           if opts

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
@@ -26,6 +26,10 @@ module ActiveRecord
           registry[key(attrs)] || default(attrs)
         end
 
+        def clear
+          @registry = {}
+        end
+
         private
 
         def default_for_type(attrs)

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
@@ -14,8 +14,8 @@ module ActiveRecord
           registry[key(attrs)] = factory
         end
 
-        def default
-          @default || RGeo::ActiveRecord::RGeoFactorySettings.new
+        def default(geo_type = "")
+          @default || default_for_type(geo_type)
         end
 
         def default=(factory)
@@ -23,10 +23,25 @@ module ActiveRecord
         end
 
         def factory(attrs)
-          registry[key(attrs)] || default
+          registry[key(attrs)] || default(attrs)
         end
 
         private
+
+        def default_for_type(attrs)
+          if attrs[:geo_type] =~ /geography/
+            RGeo::Geographic.spherical_factory(to_factory_attrs(attrs))
+          else
+            RGeo::ActiveRecord::RGeoFactorySettings.new
+          end
+        end
+
+        def to_factory_attrs(attrs)
+          attrs.slice(:srid).merge(
+            has_m_coordinate: attrs[:has_m],
+            has_z_coordinate: attrs[:has_z],
+          )
+        end
 
         def key(attrs)
           {

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
@@ -1,0 +1,43 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostGISAdapter
+      class SpatialFactoryStore
+        include Singleton
+
+        attr_accessor :registry
+
+        def initialize
+          @registry = {}
+        end
+
+        def register(factory, attrs = {})
+          registry[key(attrs)] = factory
+        end
+
+        def default
+          @default || RGeo::ActiveRecord::RGeoFactorySettings.new
+        end
+
+        def default=(factory)
+          @default = factory
+        end
+
+        def factory(attrs)
+          registry[key(attrs)] || default
+        end
+
+        private
+
+        def key(attrs)
+          {
+            geo_type: "geometry",
+            has_m: false,
+            has_z: false ,
+            sql_type: "geometry",
+            srid: 0,
+          }.merge(attrs).hash
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/spatial_factory_store.rb
@@ -14,8 +14,8 @@ module ActiveRecord
           registry[key(attrs)] = factory
         end
 
-        def default(geo_type = "")
-          @default || default_for_type(geo_type)
+        def default(attrs = {})
+          @default || default_for_attrs(attrs)
         end
 
         def default=(factory)
@@ -32,8 +32,8 @@ module ActiveRecord
 
         private
 
-        def default_for_type(attrs)
-          if attrs[:geo_type] =~ /geography/
+        def default_for_attrs(attrs)
+          if attrs[:sql_type] =~ /geography/
             RGeo::Geographic.spherical_factory(to_factory_attrs(attrs))
           else
             RGeo::ActiveRecord::RGeoFactorySettings.new
@@ -41,19 +41,20 @@ module ActiveRecord
         end
 
         def to_factory_attrs(attrs)
-          attrs.slice(:srid).merge(
+          {
             has_m_coordinate: attrs[:has_m],
             has_z_coordinate: attrs[:has_z],
-          )
+            srid:             (attrs[:srid] || 0),
+          }
         end
 
         def key(attrs)
           {
             geo_type: "geometry",
-            has_m: false,
-            has_z: false ,
+            has_m:    false,
+            has_z:    false,
             sql_type: "geometry",
-            srid: 0,
+            srid:     0,
           }.merge(attrs).hash
         end
       end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -117,9 +117,6 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
     klass.connection.change_table(:spatial_models) do |t|
       t.index(:latlon, using: :gist)
     end
-    klass.class_eval do
-      self.rgeo_factory_generator = RGeo::Geos.method(:factory)
-    end
 
     object = klass.new
     object.latlon = 'POINT(-122 47)'

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -87,16 +87,19 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
 
   def test_custom_factory
     klass = SpatialModel
-    klass.connection.create_table(:spatial_test, force: true) do |t|
-      t.st_point(:latlon, srid: 4326)
+    klass.connection.create_table(:spatial_models, force: true) do |t|
+      t.st_polygon(:area, srid: 4326)
     end
-    factory = RGeo::Geographic.simple_mercator_factory
-    klass.class_eval do
-      set_rgeo_factory_for_column(:latlon, factory)
-    end
-    assert_equal factory, klass.rgeo_factory_for_column(:latlon)
+    klass.reset_column_information
+    custom_factory = RGeo::Geographic.spherical_factory(buffer_resolution: 8, srid: 4326)
+    spatial_factory_store.register(custom_factory, geo_type: "polygon", srid: 4326)
     object = klass.new
-    assert_equal factory, object.class.rgeo_factory_for_column(:latlon)
+    area = custom_factory.point(1, 2).buffer(3)
+    object.area = area
+    object.save!
+    object.reload
+    assert_equal area.to_s, object.area.to_s
+    spatial_factory_store.clear
   end
 
   def test_readme_example

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -100,7 +100,7 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
   end
 
   def test_readme_example
-    ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialFactoryStore.instance.register(
+    spatial_factory_store.register(
       RGeo::Geographic.spherical_factory, geo_type: "point", sql_type: "geography")
 
     klass = SpatialModel
@@ -124,6 +124,8 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
     assert_equal 47, point.latitude
     object.shape = point
     # assert_equal true, RGeo::Geos.is_geos?(object.shape)
+
+    spatial_factory_store.clear
   end
 
   def test_point_to_json
@@ -150,5 +152,9 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
       t.column 'latlon_geo', :st_point, srid: 4326, geographic: true
     end
     SpatialModel.reset_column_information
+  end
+
+  def spatial_factory_store
+    ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialFactoryStore.instance
   end
 end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -100,6 +100,9 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
   end
 
   def test_readme_example
+    ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialFactoryStore.instance.register(
+      RGeo::Geographic.spherical_factory, geo_type: "point", sql_type: "geography")
+
     klass = SpatialModel
     klass.connection.create_table(:spatial_models, force: true) do |t|
       t.column(:shape, :geometry)
@@ -113,8 +116,8 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
     end
     klass.class_eval do
       self.rgeo_factory_generator = RGeo::Geos.method(:factory)
-      set_rgeo_factory_for_column(:latlon, RGeo::Geographic.spherical_factory)
     end
+
     object = klass.new
     object.latlon = 'POINT(-122 47)'
     point = object.latlon
@@ -149,4 +152,3 @@ class BasicTest < ActiveSupport::TestCase  # :nodoc:
     SpatialModel.reset_column_information
   end
 end
-

--- a/test/spatial_factory_store_test.rb
+++ b/test/spatial_factory_store_test.rb
@@ -41,6 +41,6 @@ class SpatialFactoryStoreTest < ActiveSupport::TestCase
   private
 
   def store
-    ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialFactoryStore.instance
+    spatial_factory_store
   end
 end

--- a/test/spatial_factory_store_test.rb
+++ b/test/spatial_factory_store_test.rb
@@ -35,6 +35,7 @@ class SpatialFactoryStoreTest < ActiveSupport::TestCase
     assert_equal z_point_factory, store.factory(geo_type: "point", has_z: true)
 
     assert_equal default_factory, store.factory(geo_type: "linestring")
+    store.clear
   end
 
   private

--- a/test/spatial_factory_store_test.rb
+++ b/test/spatial_factory_store_test.rb
@@ -1,18 +1,23 @@
 require "test_helper"
 
 class SpatialFactoryStoreTest < ActiveSupport::TestCase
-  def test_everything
-    # it's a singleton, so random test runs won't work :(
-
-    # default
+  def test_default
+    store.clear
     assert RGeo::ActiveRecord::RGeoFactorySettings === store.default
+  end
 
-    # set default
+  def test_set_default
+    store.clear
     default_factory = Object.new
     store.default = default_factory
     assert_equal default_factory, store.default
+  end
 
-    # register
+  def test_register
+    store.clear
+    default_factory = Object.new
+    store.default = default_factory
+
     point_factory = Object.new
     store.register point_factory, geo_type: "point", srid: 4326
     assert_equal point_factory, store.factory(geo_type: "point", srid: 4326)

--- a/test/spatial_factory_store_test.rb
+++ b/test/spatial_factory_store_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class SpatialFactoryStoreTest < ActiveSupport::TestCase
+  def test_everything
+    # it's a singleton, so random test runs won't work :(
+
+    # default
+    assert RGeo::ActiveRecord::RGeoFactorySettings === store.default
+
+    # set default
+    default_factory = Object.new
+    store.default = default_factory
+    assert_equal default_factory, store.default
+
+    # register
+    point_factory = Object.new
+    store.register point_factory, geo_type: "point", srid: 4326
+    assert_equal point_factory, store.factory(geo_type: "point", srid: 4326)
+    assert_equal 1, store.registry.size
+    assert_equal point_factory, store.factory(geo_type: "point", srid: 4326)
+    assert_equal 1, store.registry.size
+
+    polygon_factory = Object.new
+    store.register polygon_factory, geo_type: "polygon"
+    assert_equal polygon_factory, store.factory(geo_type: "polygon")
+    assert_equal 2, store.registry.size
+
+    z_point_factory = Object.new
+    store.register z_point_factory, geo_type: "point", has_z: true
+    assert_equal z_point_factory, store.factory(geo_type: "point", has_z: true)
+
+    assert_equal default_factory, store.factory(geo_type: "linestring")
+  end
+
+  private
+
+  def store
+    ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialFactoryStore.instance
+  end
+end

--- a/test/spatial_factory_store_test.rb
+++ b/test/spatial_factory_store_test.rb
@@ -11,6 +11,7 @@ class SpatialFactoryStoreTest < ActiveSupport::TestCase
     default_factory = Object.new
     store.default = default_factory
     assert_equal default_factory, store.default
+    store.default = nil
   end
 
   def test_register

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,4 +26,7 @@ class ActiveSupport::TestCase
     RGeo::Geographic.spherical_factory(srid: 4326)
   end
 
+  def spatial_factory_store
+    ActiveRecord::ConnectionAdapters::PostGISAdapter::SpatialFactoryStore.instance
+  end
 end


### PR DESCRIPTION
We just upgraded our application to Rails 4.2 and also to activerecord-postgis-adapter 3.0.0.beta1 and ran into a problem I want to report here.

Before the upgrade the custom factories we set per column worked really well:

```
set_rgeo_factory_for_column(:latlon, RGeo::Geographic.spherical_factory(:srid => 4326))
```

Now the factory setting gets ignored. We always get back "CAPI"-Implementations and not the implementations of the specified factory when reading from the database.

I dug into the code of activerecord-postgis-adapter and built a test case:

```ruby
  def test_loading_with_custom_factory
    klass = SpatialModel
    klass.connection.create_table(:spatial_test, force: true) do |t|
      t.spatial(:latlon, srid: 4326, type: 'point')
    end

    factory = RGeo::Geographic.spherical_factory(srid: 4326)
    klass.class_eval do
      set_rgeo_factory_for_column(:latlon, factory)
    end

    obj = SpatialModel.new
    obj.latlon = 'POINT(1 2)'
    obj.save!

    id = obj.id
    obj2 = SpatialModel.find(id)
    assert_equal factory.class, obj2.latlon.factory.class
  end
```

This fails:

```
  1) Failure:
BasicTest#test_loading_with_custom_factory [test/basic_test.rb:119]:
Expected: RGeo::Geographic::Factory
  Actual: RGeo::Geos::CAPIFactory
```

And that's exactly the problem we have in our application.

It seems like the factory settings are stored in `SpatialColumn` and the parsing is done in `OID::Spatial`. In `OID::Spatial` the factory settings are not used:

```ruby
def parse_wkt(string)
  # factory = factory_settings.get_column_factory(table_name, column, constraints)
  factory = @factory_generator || RGeo::ActiveRecord::RGeoFactorySettings.new
  wkt_parser(factory, string).parse(string)
rescue RGeo::Error::ParseError
  nil
end
```

The line that's commented out is exactly the one we need. But un-commenting it doesn't do anything but break the code. `OID::Spatial` has no access to the `table_name` and `column` and `constraints`.

Do you have any ideas regarding this problem? Do you want to leave it as it is, since it seems difficult to solve with the new PostgreSQL adapter architecture in Rails 4.2, or try to fix it? Any idea what I can try to help?

