### PR TITLE
Ignore PostGIS views when schema dumping

### DIFF
--- a/lib/active_record/connection_adapters/postgis/setup.rb
+++ b/lib/active_record/connection_adapters/postgis/setup.rb
@@ -2,7 +2,15 @@ module ActiveRecord  # :nodoc:
   module ConnectionAdapters  # :nodoc:
     module PostGIS  # :nodoc:
       def self.initial_setup
-        ::ActiveRecord::SchemaDumper.ignore_tables |= %w(geometry_columns spatial_ref_sys layer topology)
+        ::ActiveRecord::SchemaDumper.ignore_tables |= %w(
+          geography_columns
+          geometry_columns
+          layer
+          raster_columns
+          raster_overviews
+          spatial_ref_sys
+          topology
+        )
       end
     end
   end

--- a/test/setup_test.rb
+++ b/test/setup_test.rb
@@ -2,6 +2,15 @@ require "test_helper"
 
 class SpatialQueriesTest < ActiveSupport::TestCase  # :nodoc:
   def test_ignore_tables
-    assert_equal %w(geometry_columns spatial_ref_sys layer topology), ::ActiveRecord::SchemaDumper.ignore_tables
+    expect_to_ignore = %w(
+      geography_columns
+      geometry_columns
+      layer
+      raster_columns
+      raster_overviews
+      spatial_ref_sys
+      topology
+    )
+    assert_equal expect_to_ignore, ::ActiveRecord::SchemaDumper.ignore_tables
   end
 end


### PR DESCRIPTION
Rails has no support for views natively, but several gems ([Scenic]
included), do add support for them. Using them with PostGIS can cause
the PostGIS views themselves to be dumped.

The PostGIS adapter already ignores its own tables. This change adds the
view names that I'm aware of to the list.

See: https://github.com/thoughtbot/scenic/issues/134

[Scenic]: https://github.com/thoughtbot/scenic