### PR TITLE
Add missing configuration option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ development:
   adapter: postgis
   encoding: unicode
   postgis_extension: postgis      # default is postgis
+  postgis_schema: public          # default is public
   schema_search_path: public,postgis
   pool: 5
   database: my_app_development    # your database name


### PR DESCRIPTION
This is an option that appears to have been supported since 2.x, but is missing from the documentation.

Because my database uses postgis within the `postgis` schema instead of `public`, this configuration option was necessary when upgrading to 2.x.