### PR TITLE
adjusted call to new TableDefinition due to rails change

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -73,8 +73,8 @@ module ActiveRecord
         end
 
         # override
-        def create_table_definition(name, temporary, options, as = nil)
-          PostGIS::TableDefinition.new(native_database_types, name, temporary, options, as)
+        def create_table_definition(*args)
+          PostGIS::TableDefinition.new(*args)
         end
 
         # memoize hash of column infos for tables


### PR DESCRIPTION
There was a shift active record TableDefinition towards using keyword arguments. (noiticed when trying out with rails 5 beta)

I fixed the incompatibility  by passing the arguments of create_table_definition directly to the initialize method of the PostGIS::TableDefinition 