### PR TITLE
fixing schema dumping for active record 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 /gemfiles/*.gemfile.lock
 /travis/*.lock
 /test/database_local.yml
+.idea

--- a/lib/active_record/connection_adapters/postgis/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column.rb
@@ -1,7 +1,7 @@
-module ActiveRecord  # :nodoc:
-  module ConnectionAdapters  # :nodoc:
-    module PostGIS  # :nodoc:
-      class SpatialColumn < ConnectionAdapters::PostgreSQLColumn  # :nodoc:
+module ActiveRecord # :nodoc:
+  module ConnectionAdapters # :nodoc:
+    module PostGIS # :nodoc:
+      class SpatialColumn < ConnectionAdapters::PostgreSQLColumn # :nodoc:
         # sql_type examples:
         #   "Geometry(Point,4326)"
         #   "Geography(Point,4326)"
@@ -30,7 +30,7 @@ module ActiveRecord  # :nodoc:
           super(name, default, cast_type, sql_type, null, default_function)
           if spatial?
             if @srid
-              @limit = { srid: @srid, type: geometric_type.type_name.underscore }
+              @limit = {srid: @srid, type: active_record_version_aware_type_name(geometric_type)}
               @limit[:has_z] = true if @has_z
               @limit[:has_m] = true if @has_m
               @limit[:geographic] = true if @geographic
@@ -61,6 +61,22 @@ module ActiveRecord  # :nodoc:
         end
 
         private
+
+        def active_record_version_aware_type_name(geometric_type)
+          type_name = geometric_type.type_name.underscore
+          if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR > 1
+            case type_name
+              when 'point'
+                'st_point'
+              when 'polygon'
+                'st_polygon'
+              else
+                type_name
+            end
+          else
+            type_name
+          end
+        end
 
         def set_geometric_type_from_name(name)
           @geometric_type = RGeo::ActiveRecord.geometric_type_from_name(name) || RGeo::Feature::Geometry

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -228,7 +228,7 @@ class DDLTest < ActiveSupport::TestCase  # :nodoc:
     assert_equal false, col.has_z?
     assert_equal true, col.has_m?
     assert_equal 3785, col.srid
-    assert_equal({ has_m: true, type: "polygon", srid: 3785 }, col.limit)
+    assert_equal({ has_m: true, type: "st_polygon", srid: 3785 }, col.limit)
     klass.connection.drop_table(:spatial_models)
     assert_equal 0, count_geometry_columns
   end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -91,8 +91,8 @@ class TasksTest < ActiveSupport::TestCase  # :nodoc:
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
     data = File.read(tmp_sql_filename)
-    assert data.index(%(t.geography "latlon1", limit: {:srid=>4326, :type=>"point", :geographic=>true}))
-    assert data.index(%(t.geography "latlon2", limit: {:srid=>4326, :type=>"point", :geographic=>true}))
+    assert data.index(%(t.geography "latlon1", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}))
+    assert data.index(%(t.geography "latlon2", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}))
   end
 
   def test_index_schema_dump
@@ -105,7 +105,7 @@ class TasksTest < ActiveSupport::TestCase  # :nodoc:
       ActiveRecord::SchemaDumper.dump(connection, file)
     end
     data = File.read(tmp_sql_filename)
-    assert data.index(%(t.geography "latlon", limit: {:srid=>4326, :type=>"point", :geographic=>true}))
+    assert data.index(%(t.geography "latlon", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}))
     assert data.index(%(add_index "spatial_test", ["latlon"], name: "index_spatial_test_on_latlon", using: :gist))
   end
 


### PR DESCRIPTION
As said in the documentation: "In ActiveRecord 4.2, the Postgresql adapter added support for the native Postgresql point and polygon types, which conflict with this adapter's types of the same names.". Rails SchemaDumper used incorrect type for generated column definitions, e.g.:
t.geography "lonlat", limit: {:srid=>4326, :type=>"point", :has_z=>true, :geographic=>true}

This fix sets correct types st_point and st_polygon. So with that fix Schema Dumper gives:
t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :has_z=>true, :geographic=>true}
