### PR TITLE
Fix schema dump null issues in JRuby

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -10,7 +10,8 @@ module ActiveRecord
             oid = get_oid_type(oid.to_i, fmod.to_i, column_name, type)
             default_value = extract_value_from_default(oid, default)
             default_function = extract_default_function(default_value, default)
-            new_column(table_name, column_name, default_value, oid, type, notnull == "f", default_function)
+            notnull = notnull == "t" if notnull.is_a?(String) # JDBC gets true/false
+            new_column(table_name, column_name, default_value, oid, type, !notnull, default_function)
           end
         end
 


### PR DESCRIPTION
This picks up on @miwelc's work from https://github.com/rgeo/activerecord-postgis-adapter/pull/192. It updates it to merge cleanly on master and adds tests.

This overall issue is a bit fuzzier now than it used to be, since activerecord-jdbc-adapter 1.3.18+ no longer exhibits this issue by default (the jdbc adapter now uses the same default behavior as the normal postgresql adapter). However, it's still possible this bug can crop up if you're using an older version of activerecord-jdbc-adapter (before 1.3.18) or if you've tweaked the `ActiveRecord::ConnectionAdapters::PostgreSQLJdbcConnection.raw_boolean` setting. So it would still be nice to see this fixed. For a bit more detail on the recent activerecord-jdbc-adapter changes, see:  https://github.com/jruby/activerecord-jdbc-adapter/issues/722#issuecomment-216656410

Let me know if you have any questions or would prefer I squash this all to one commit. Thanks!