### PR TITLE
Call to super does not match initialize parameters

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -31,6 +31,7 @@ module ActiveRecord
                             default,
                             sql_type_metadata,
                             null,
+                            table_name,
                             default_function,
                             collation,
                             cast_type,

--- a/lib/active_record/connection_adapters/postgis/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column.rb
@@ -8,7 +8,7 @@ module ActiveRecord  # :nodoc:
         # cast_type example classes:
         #   OID::Spatial
         #   OID::Integer
-        def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil, cast_type = nil, opts = nil)
+        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, cast_type = nil, opts = nil)
           @cast_type = cast_type
           @geographic = !!(sql_type_metadata.sql_type =~ /geography\(/i)
           if opts
@@ -29,7 +29,7 @@ module ActiveRecord  # :nodoc:
             # @geometric_type = geo_type_from_sql_type(sql_type)
             build_from_sql_type(sql_type_metadata.sql_type)
           end
-          super(name, default, sql_type_metadata, null, default_function, collation)
+          super(name, default, sql_type_metadata, null, table_name, default_function, collation)
           if spatial?
             if @srid
               @limit = { srid: @srid, type: geometric_type.type_name.underscore }


### PR DESCRIPTION
SpatialColumn inherits from PostgreSQLColumn (which inherits from [`Column`](https://github.com/rails/rails/blob/e8c21ff645eefb889acd7799bd12c9757cd8fd8c/activerecord/lib/active_record/connection_adapters/column.rb)) and it's call to super should match it's own initialize signature.

This change is related to rgeo/activerecord-postgis-adapter#175 because under the right circumstances, `default_function` is passed to super with a nil value setting the wrong default_function.

@teeparham I'd like to hear your thoughts on how to test this out...