### PR TITLE
Autoload PostGISDatabaseTasks to avoid memory leaks in multithread

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -15,7 +15,6 @@ require "active_record/connection_adapters/postgis/arel_tosql"
 require "active_record/connection_adapters/postgis/setup"
 require "active_record/connection_adapters/postgis/oid/spatial"
 require "active_record/connection_adapters/postgis/create_connection"
-require "active_record/connection_adapters/postgis/postgis_database_tasks"
 
 ::ActiveRecord::ConnectionAdapters::PostGIS.initial_setup
 

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -16,6 +16,17 @@ require "active_record/connection_adapters/postgis/setup"
 require "active_record/connection_adapters/postgis/oid/spatial"
 require "active_record/connection_adapters/postgis/create_connection"
 
+module ActiveRecord  # :nodoc:
+  module ConnectionAdapters  # :nodoc:
+    module PostGIS  # :nodoc:
+      extend ActiveSupport::Autoload
+
+      autoload :PostGISDatabaseTasks,
+        "active_record/connection_adapters/postgis/postgis_database_tasks"
+    end
+  end
+end
+
 ::ActiveRecord::ConnectionAdapters::PostGIS.initial_setup
 
 if defined?(::Rails::Railtie)

--- a/lib/activerecord-postgis-adapter.rb
+++ b/lib/activerecord-postgis-adapter.rb
@@ -1,12 +1,1 @@
 require "active_record/connection_adapters/postgis_adapter.rb"
-
-module ActiveRecord  # :nodoc:
-  module ConnectionAdapters  # :nodoc:
-    module PostGIS  # :nodoc:
-      extend ActiveSupport::Autoload
-
-      autoload :PostGISDatabaseTasks,
-        'active_record/connection_adapters/postgis/postgis_database_tasks'
-    end
-  end
-end

--- a/lib/activerecord-postgis-adapter.rb
+++ b/lib/activerecord-postgis-adapter.rb
@@ -1,1 +1,12 @@
 require "active_record/connection_adapters/postgis_adapter.rb"
+
+module ActiveRecord  # :nodoc:
+  module ConnectionAdapters  # :nodoc:
+    module PostGIS  # :nodoc:
+      extend ActiveSupport::Autoload
+
+      autoload :PostGISDatabaseTasks,
+        'active_record/connection_adapters/postgis/postgis_database_tasks'
+    end
+  end
+end


### PR DESCRIPTION
Issue described in #236
PostGISDatabaseTasks is not multithread-prof. It should be required on needed.