### PR TITLE
Avoid spaces in the beginning of schema names

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
@@ -101,7 +101,7 @@ module ActiveRecord  # :nodoc:
           # We needed to modify the catalog queries to pull the index type info.
 
           # Remove postgis from schemas
-          schemas_ = schema_search_path.split(/,/)
+          schemas_ = schema_search_path.split(/,/).map(&:strip)
           schemas_.delete('postgis')
           schemas_ = schemas_.map{ |p_| quote(p_) }.join(',')
 

--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
@@ -103,7 +103,7 @@ module ActiveRecord  # :nodoc:
           # Remove postgis from schemas
           schemas_ = schema_search_path.split(/,/).map(&:strip)
           schemas_.delete('postgis')
-          schemas_ = schemas_.map{ |p_| quote(p_) }.join(',')
+          schemas_ = schemas_.map{ |p_| quote(p_) }.join(', ')
 
           # Get index type by joining with pg_am.
           result_ = query(<<-SQL, name_)


### PR DESCRIPTION
When schema contains multiple values, for example "schema1, schema2", names will contain leading space (" schema2") after splitting.
This patch fixes this issue.