### PR TITLE
Allow rgeo-activerecord 5.x

### DIFF
--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2.2"
 
   spec.add_dependency "activerecord", "~> 5.0.0"
-  spec.add_dependency "rgeo-activerecord", "~> 5.0.0"
+  spec.add_dependency "rgeo-activerecord", "~> 5.0"
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.4"


### PR DESCRIPTION
First step to support ActiveRecord 5.1. ( #248 )

The rgeo-activerecord gem seems fine with AR 5.1.