### PR TITLE
Use PG::Connection instead of PGconn

### DIFF
--- a/lib/active_record/connection_adapters/postgis/create_connection.rb
+++ b/lib/active_record/connection_adapters/postgis/create_connection.rb
@@ -30,7 +30,7 @@ module ActiveRecord  # :nodoc:
         conn_params[:dbname] = conn_params.delete(:database) if conn_params[:database]
 
         # Forward only valid config params to PGconn.connect.
-        valid_conn_param_keys = PGconn.conndefaults_hash.keys + [:requiressl]
+        valid_conn_param_keys = PG::Connection.conndefaults_hash.keys + [:requiressl]
         conn_params.slice!(*valid_conn_param_keys)
 
         # The postgres drivers don't allow the creation of an unconnected PGconn object,


### PR DESCRIPTION
pg 0.21 emits warnings

```
The PGconn, PGresult, and PGError constants are deprecated, and will be
removed as of version 1.0.
```