### PR TITLE
fix regex for parsing spacial column types

### DIFF
--- a/lib/active_record/connection_adapters/postgis/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/postgis/oid/spatial.rb
@@ -24,9 +24,9 @@ module ActiveRecord
           def self.parse_sql_type(sql_type)
             geo_type, srid, has_z, has_m = nil, 0, false, false
 
-            if sql_type =~ /[geography,geometry]\((.*)\)$/i
+            if sql_type =~ /(geography|geometry)\((.*)\)$/i
               # geometry(Point,4326)
-              params = Regexp.last_match(1).split(",")
+              params = Regexp.last_match(2).split(",")
               if params.size > 1
                 if params.first =~ /([a-z]+[^zm])(z?)(m?)/i
                   has_z = Regexp.last_match(2).length > 0


### PR DESCRIPTION
This fixes:
1. ruby warning: `warning: character class has duplicated range: /[geography,geometry]\((.*)\)$/`
2. wrongly matches of any type for which the name ends with any of the characters: g, e, o, r, a, p, h, y, m, t