### PR TITLE
Require rgeo-activerecord 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
-  - jruby-9.0.5.0
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
+  - jruby-9.1.9.0
 gemfile:
   - gemfiles/ar51.gemfile
   - gemfiles/ar52.gemfile
 matrix:
   allow_failures:
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.9.0
 addons:
   postgresql: "9.4"
   apt:

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2.2"
 
   spec.add_dependency "activerecord", "~> 5.1"
-  spec.add_dependency "rgeo-activerecord", "~> 5.1"
+  spec.add_dependency "rgeo-activerecord", "~> 6.0"
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.4"


### PR DESCRIPTION
* Requires rgeo 1.0

If you are using proj.4, you must now require the rgeo-proj4 gem:

```ruby
gem "rgeo-proj4"
```