### PR TITLE
Enable column comment

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -6,7 +6,7 @@ module ActiveRecord
         # pass table_name to #new_column
         def columns(table_name)
           # Limit, precision, and scale are all handled by the superclass.
-          column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod, collation|
+          column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod, collation, comment|
             oid = oid.to_i
             fmod = fmod.to_i
             type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
@@ -14,12 +14,12 @@ module ActiveRecord
             default_value = extract_value_from_default(default)
 
             default_function = extract_default_function(default_value, default)
-            new_column(table_name, column_name, default_value, cast_type, type_metadata, !notnull, default_function, collation)
+            new_column(table_name, column_name, default_value, cast_type, type_metadata, !notnull, default_function, collation, comment)
           end
         end
 
         # override
-        def new_column(table_name, column_name, default, cast_type, sql_type_metadata = nil, null = true, default_function = nil, collation = nil)
+        def new_column(table_name, column_name, default, cast_type, sql_type_metadata = nil, null = true, default_function = nil, collation = nil, comment = nil)
           # JDBC gets true/false in Rails 4, where other platforms get 't'/'f' strings.
           if null.is_a?(String)
             null = (null == "t")
@@ -34,6 +34,7 @@ module ActiveRecord
                             table_name,
                             default_function,
                             collation,
+                            comment,
                             cast_type,
                             column_info)
         end

--- a/lib/active_record/connection_adapters/postgis/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column.rb
@@ -29,7 +29,7 @@ module ActiveRecord  # :nodoc:
             # @geometric_type = geo_type_from_sql_type(sql_type)
             build_from_sql_type(sql_type_metadata.sql_type)
           end
-          super(name, default, sql_type_metadata, null, table_name, default_function, collation, comment: comment.presence)
+          super(name, default, sql_type_metadata, null, table_name, default_function, collation, comment: comment)
           if spatial?
             if @srid
               @limit = { srid: @srid, type: to_type_name(geometric_type) }

--- a/lib/active_record/connection_adapters/postgis/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column.rb
@@ -8,7 +8,7 @@ module ActiveRecord  # :nodoc:
         # cast_type example classes:
         #   OID::Spatial
         #   OID::Integer
-        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, cast_type = nil, opts = nil)
+        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil, cast_type = nil, opts = nil)
           @cast_type = cast_type
           @geographic = !!(sql_type_metadata.sql_type =~ /geography\(/i)
           if opts
@@ -29,7 +29,7 @@ module ActiveRecord  # :nodoc:
             # @geometric_type = geo_type_from_sql_type(sql_type)
             build_from_sql_type(sql_type_metadata.sql_type)
           end
-          super(name, default, sql_type_metadata, null, table_name, default_function, collation)
+          super(name, default, sql_type_metadata, null, table_name, default_function, collation, comment: comment.presence)
           if spatial?
             if @srid
               @limit = { srid: @srid, type: to_type_name(geometric_type) }

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -306,6 +306,15 @@ class DDLTest < ActiveSupport::TestCase  # :nodoc:
     assert_equal 123, col.limit
   end
 
+  def test_column_comments
+    klass.connection.create_table(:spatial_models, force: true) do |t|
+      t.string :sample_comment, comment: 'Comment test'
+    end
+    klass.reset_column_information
+    col = klass.columns.last
+    assert_equal 'Comment test', col.comment
+  end
+
   private
 
   def klass


### PR DESCRIPTION
Motivation:
I want to print column comments on `db/schema.rb` files.
It is default feature of rails5 since rails/rails#22911