### PR TITLE
Compatibility with pg-1.0.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,4 +4,5 @@ end
 
 appraise "ar52" do
   gem "activerecord", "~> 5.2.0.beta2"
+  gem "pg", "~> 1.0", platform: :ruby
 end

--- a/gemfiles/ar52.gemfile
+++ b/gemfiles/ar52.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "pg", "~> 0.17", platform: :ruby
+gem "pg", "~> 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.9", platform: :jruby
 gem "ffi-geos", platform: :jruby
 gem "byebug", platform: :mri_24


### PR DESCRIPTION
Hi @teeparham, it seems that the `pg` gem has released a 1.0 but this library still ties the updates to `~>0.17`.

Do you think the Gemfile restriction can be updated to support 1.0?

Thank you!