### PR TITLE
Fix tests for Postgres 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.envrc
 .ruby-version
 doc/
 pkg/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,21 @@ psql -U postgres -c "create database postgis_adapter_test"
 psql -U postgres -d postgis_adapter_test -c "create extension postgis"
 ```
 
+You may also set up environment variables to define the database connection.
+See `test/database.yml` for which variables are used. All are optional.
+For example:
+
+```sh
+export PGUSER=postgis_test
+export PGPASSWORD=password123
+export PGPORT=95432
+export PGHOST=127.0.0.2
+export PGDATABASE=postgis_adapter_test
+
+psql -c "create database postgis_adapter_test"
+psql -c "create extension postgis"
+```
+
 Install dependencies:
 
 ```sh

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in activerecord-postgis-adapter.gemspec
 gemspec
 
-gem "pg", "~> 0.17", platform: :ruby
+gem "pg", "~> 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.9", platform: :jruby
 gem "ffi-geos", platform: :jruby
 gem "byebug", platform: :mri_24

--- a/gemfiles/ar51.gemfile
+++ b/gemfiles/ar51.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "pg", "~> 0.17", platform: :ruby
+gem "pg", "~> 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.9", platform: :jruby
 gem "ffi-geos", platform: :jruby
-gem "byebug", platform: :mri_23
+gem "byebug", platform: :mri_24
 gem "activerecord", "~> 5.1.0"
 
 gemspec path: "../"

--- a/gemfiles/ar52.gemfile
+++ b/gemfiles/ar52.gemfile
@@ -6,6 +6,6 @@ gem "pg", "~> 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.9", platform: :jruby
 gem "ffi-geos", platform: :jruby
 gem "byebug", platform: :mri_24
-gem "activerecord", "~> 5.2.0.beta2"
+gem "activerecord", "~> 5.2.0"
 
 gemspec path: "../"

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class BasicTest < ActiveSupport::TestCase  # :nodoc:
+class BasicTest < ActiveSupport::TestCase
   def test_version
     refute_nil ActiveRecord::ConnectionAdapters::PostGIS::VERSION
   end

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,6 +1,8 @@
 adapter: postgis
-host: 127.0.0.1
-database: postgis_adapter_test
-username: postgres
+host: <%= ENV["PGHOST"] || "127.0.0.1" %>
+port: <%= ENV["PGPORT"] || "5432" %>
+database: <%= ENV["PGDATABASE"] || "postgis_adapter_test" %>
+username: <%= ENV["PGUSER"] || "postgres" %>
+password: <%= ENV["PGPASSWORD"] || "" %>
 setup: default
 schema_search_path: public

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class DDLTest < ActiveSupport::TestCase  # :nodoc:
+class DDLTest < ActiveSupport::TestCase
   def test_spatial_column_options
     [
       :geography,

--- a/test/nested_class_test.rb
+++ b/test/nested_class_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class NestedClassTest < ActiveSupport::TestCase # :nodoc:
+class NestedClassTest < ActiveSupport::TestCase
   module Foo
     def self.table_name_prefix
       "foo_"

--- a/test/nested_class_test.rb
+++ b/test/nested_class_test.rb
@@ -2,13 +2,14 @@
 
 require "test_helper"
 
-class NestedClassTest < ActiveSupport::TestCase  # :nodoc:
+class NestedClassTest < ActiveSupport::TestCase # :nodoc:
   module Foo
     def self.table_name_prefix
       "foo_"
     end
+
     class Bar < ActiveRecord::Base
-      establish_connection YAML.load_file(ActiveSupport::TestCase::DATABASE_CONFIG_PATH)
+      establish_test_connection
     end
   end
 

--- a/test/setup_test.rb
+++ b/test/setup_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class SpatialQueriesTest < ActiveSupport::TestCase  # :nodoc:
+class SpatialQueriesTest < ActiveSupport::TestCase
   def test_ignore_tables
     expect_to_ignore = %w(
       geography_columns

--- a/test/spatial_queries_test.rb
+++ b/test/spatial_queries_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class SpatialQueriesTest < ActiveSupport::TestCase  # :nodoc:
+class SpatialQueriesTest < ActiveSupport::TestCase
   def test_query_point
     create_model
     obj = SpatialModel.new

--- a/test/spatial_queries_test.rb
+++ b/test/spatial_queries_test.rb
@@ -5,53 +5,56 @@ require "test_helper"
 class SpatialQueriesTest < ActiveSupport::TestCase
   def test_query_point
     create_model
-    obj = SpatialModel.new
-    obj.latlon = factory.point(1.0, 2.0)
-    obj.save!
+    obj = SpatialModel.create!(latlon: factory.point(1, 2))
     id = obj.id
-    obj2 = SpatialModel.where(latlon: factory.multi_point([factory.point(1.0, 2.0)])).first
-    refute_nil(obj2)
-    assert_equal(id, obj2.id)
-    obj3 = SpatialModel.where(latlon: factory.point(2.0, 2.0)).first
-    assert_nil(obj3)
+    assert_empty SpatialModel.where(latlon: factory.point(2, 2))
+    obj1 = SpatialModel.find_by(latlon: factory.point(1, 2))
+    refute_nil(obj1)
+    assert_equal id, obj1.id
+  end
+
+  def test_query_multi_point
+    # why doesn't this work with PG 10?
+    unless pg_10?
+      create_model
+      obj = SpatialModel.create!(latlon: factory.point(1, 2))
+      id = obj.id
+      obj2 = SpatialModel.find_by(latlon: factory.multi_point([factory.point(1, 2)]))
+      refute_nil(obj2)
+      assert_equal(id, obj2.id)
+    end
   end
 
   def test_query_point_wkt
     create_model
-    obj = SpatialModel.new
-    obj.latlon = factory.point(1.0, 2.0)
-    obj.save!
+    obj = SpatialModel.create!(latlon: factory.point(1, 2))
     id = obj.id
-    obj2 = SpatialModel.where(latlon: "SRID=3785;POINT(1 2)").first
+    obj2 = SpatialModel.find_by(latlon: "SRID=3785;POINT(1 2)")
     refute_nil(obj2)
     assert_equal(id, obj2.id)
-    obj3 = SpatialModel.where(latlon: "SRID=3785;POINT(2 2)").first
+    obj3 = SpatialModel.find_by(latlon: "SRID=3785;POINT(2 2)")
     assert_nil(obj3)
   end
 
   def test_query_st_distance
     create_model
-    obj = SpatialModel.new
-    obj.latlon = factory.point(1.0, 2.0)
-    obj.save!
+    obj = SpatialModel.create!(latlon: factory.point(1, 2))
     id = obj.id
-    obj2 = SpatialModel.where(SpatialModel.arel_table[:latlon].st_distance("SRID=3785;POINT(2 3)").lt(2)).first
+    obj2 = SpatialModel.find_by(SpatialModel.arel_table[:latlon].st_distance("SRID=3785;POINT(2 3)").lt(2))
     refute_nil(obj2)
     assert_equal(id, obj2.id)
-    obj3 = SpatialModel.where(SpatialModel.arel_table[:latlon].st_distance("SRID=3785;POINT(2 3)").gt(2)).first
+    obj3 = SpatialModel.find_by(SpatialModel.arel_table[:latlon].st_distance("SRID=3785;POINT(2 3)").gt(2))
     assert_nil(obj3)
   end
 
   def test_query_st_distance_from_constant
     create_model
-    obj = SpatialModel.new
-    obj.latlon = factory.point(1.0, 2.0)
-    obj.save!
+    obj = SpatialModel.create!(latlon: factory.point(1, 2))
     id = obj.id
-    obj2 = SpatialModel.where(::Arel.spatial("SRID=3785;POINT(2 3)").st_distance(SpatialModel.arel_table[:latlon]).lt(2)).first
+    obj2 = SpatialModel.find_by(Arel.spatial("SRID=3785;POINT(2 3)").st_distance(SpatialModel.arel_table[:latlon]).lt(2))
     refute_nil(obj2)
     assert_equal(id, obj2.id)
-    obj3 = SpatialModel.where(::Arel.spatial("SRID=3785;POINT(2 3)").st_distance(SpatialModel.arel_table[:latlon]).gt(2)).first
+    obj3 = SpatialModel.find_by(Arel.spatial("SRID=3785;POINT(2 3)").st_distance(SpatialModel.arel_table[:latlon]).gt(2))
     assert_nil(obj3)
   end
 
@@ -61,10 +64,10 @@ class SpatialQueriesTest < ActiveSupport::TestCase
     obj.path = factory.line(factory.point(1.0, 2.0), factory.point(3.0, 2.0))
     obj.save!
     id = obj.id
-    obj2 = SpatialModel.where(SpatialModel.arel_table[:path].st_length.eq(2)).first
+    obj2 = SpatialModel.find_by(SpatialModel.arel_table[:path].st_length.eq(2))
     refute_nil(obj2)
     assert_equal(id, obj2.id)
-    obj3 = SpatialModel.where(SpatialModel.arel_table[:path].st_length.gt(3)).first
+    obj3 = SpatialModel.find_by(SpatialModel.arel_table[:path].st_length.gt(3))
     assert_nil(obj3)
   end
 

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TasksTest < ActiveSupport::TestCase # :nodoc:
+class TasksTest < ActiveSupport::TestCase
   def test_create_database_from_extension_in_public_schema
     drop_db_if_exists
     ActiveRecord::Tasks::DatabaseTasks.create(new_connection)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "minitest/autorun"
 require "minitest/pride"
 require "mocha/minitest"
 require "activerecord-postgis-adapter"
+require "erb"
 
 begin
   require "byebug"
@@ -11,24 +12,38 @@ rescue LoadError
   # ignore
 end
 
-class ActiveSupport::TestCase
-  self.test_order = :sorted
+module ActiveSupport
+  class TestCase
+    self.test_order = :sorted
 
-  DATABASE_CONFIG_PATH = File.dirname(__FILE__) << "/database.yml"
+    def factory
+      RGeo::Cartesian.preferred_factory(srid: 3785)
+    end
 
-  class SpatialModel < ActiveRecord::Base
-    establish_connection YAML.load_file(DATABASE_CONFIG_PATH)
+    def geographic_factory
+      RGeo::Geographic.spherical_factory(srid: 4326)
+    end
+
+    def spatial_factory_store
+      RGeo::ActiveRecord::SpatialFactoryStore.instance
+    end
   end
+end
 
-  def factory
-    RGeo::Cartesian.preferred_factory(srid: 3785)
-  end
+module ActiveRecord
+  class Base
+    DATABASE_CONFIG_PATH = File.dirname(__FILE__) << "/database.yml"
 
-  def geographic_factory
-    RGeo::Geographic.spherical_factory(srid: 4326)
-  end
+    def self.test_connection_hash
+      YAML.load(ERB.new(File.read(DATABASE_CONFIG_PATH)).result)
+    end
 
-  def spatial_factory_store
-    RGeo::ActiveRecord::SpatialFactoryStore.instance
+    def self.establish_test_connection
+      establish_connection test_connection_hash
+    end
   end
+end
+
+class SpatialModel < ActiveRecord::Base
+  establish_test_connection
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,24 +12,6 @@ rescue LoadError
   # ignore
 end
 
-module ActiveSupport
-  class TestCase
-    self.test_order = :sorted
-
-    def factory
-      RGeo::Cartesian.preferred_factory(srid: 3785)
-    end
-
-    def geographic_factory
-      RGeo::Geographic.spherical_factory(srid: 4326)
-    end
-
-    def spatial_factory_store
-      RGeo::ActiveRecord::SpatialFactoryStore.instance
-    end
-  end
-end
-
 module ActiveRecord
   class Base
     DATABASE_CONFIG_PATH = File.dirname(__FILE__) << "/database.yml"
@@ -46,4 +28,30 @@ end
 
 class SpatialModel < ActiveRecord::Base
   establish_test_connection
+end
+
+module ActiveSupport
+  class TestCase
+    self.test_order = :sorted
+
+    def database_version
+      @database_version ||= SpatialModel.connection.select_value("SELECT version()")
+    end
+
+    def pg_10?
+      database_version.include?("PostgreSQL 10")
+    end
+
+    def factory
+      RGeo::Cartesian.preferred_factory(srid: 3785)
+    end
+
+    def geographic_factory
+      RGeo::Geographic.spherical_factory(srid: 4326)
+    end
+
+    def spatial_factory_store
+      RGeo::ActiveRecord::SpatialFactoryStore.instance
+    end
+  end
 end


### PR DESCRIPTION
With this commit, the tests pass against either PG 9.6 or 10.
Travis is still running PG 9.6. The update to travis will
need to be done in a separate commit, since Travis support for
PG 10 is still questionable.

* Fix task tests for PG 10
* Test with pg gem version 1.x

* Use ENV to configure the test database connection.

Use the same defaults, but allow overriding with any of these:

PGHOST
PGDATABASE
PGPORT
PGUSER
PGPASSWORD