### PR TITLE
Add support for Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - jruby-9.2.6.0

--- a/lib/active_record/connection_adapters/postgis/column_methods.rb
+++ b/lib/active_record/connection_adapters/postgis/column_methods.rb
@@ -6,43 +6,43 @@ module ActiveRecord
       module ColumnMethods
         def spatial(name, options = {})
           raise "You must set a type. For example: 't.spatial type: :st_point'" unless options[:type]
-          column(name, options[:type], options)
+          column(name, options[:type], **options)
         end
 
         def geography(name, options = {})
-          column(name, :geography, options)
+          column(name, :geography, **options)
         end
 
         def geometry(name, options = {})
-          column(name, :geometry, options)
+          column(name, :geometry, **options)
         end
 
         def geometry_collection(name, options = {})
-          column(name, :geometry_collection, options)
+          column(name, :geometry_collection, **options)
         end
 
         def line_string(name, options = {})
-          column(name, :line_string, options)
+          column(name, :line_string, **options)
         end
 
         def multi_line_string(name, options = {})
-          column(name, :multi_line_string, options)
+          column(name, :multi_line_string, **options)
         end
 
         def multi_point(name, options = {})
-          column(name, :multi_point, options)
+          column(name, :multi_point, **options)
         end
 
         def multi_polygon(name, options = {})
-          column(name, :multi_polygon, options)
+          column(name, :multi_polygon, **options)
         end
 
         def st_point(name, options = {})
-          column(name, :st_point, options)
+          column(name, :st_point, **options)
         end
 
         def st_polygon(name, options = {})
-          column(name, :st_polygon, options)
+          column(name, :st_polygon, **options)
         end
       end
     end

--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         end
 
         # override
-        # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L523
+        # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L544
         #
         # returns Postgresql sql type string
         # examples:
@@ -74,8 +74,8 @@ module ActiveRecord
         end
 
         # override
-        def create_table_definition(*args)
-          PostGIS::TableDefinition.new(self, *args)
+        def create_table_definition(*args, **kwargs)
+          PostGIS::TableDefinition.new(self, *args, **kwargs)
         end
 
         # memoize hash of column infos for tables

--- a/lib/active_record/connection_adapters/postgis/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_table_definition.rb
@@ -7,7 +7,7 @@ module ActiveRecord  # :nodoc:
         include ColumnMethods
 
         # super: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
-        def new_column_definition(name, type, options)
+        def new_column_definition(name, type, **options)
           if (info = PostGISAdapter.spatial_column_options(type.to_sym))
             if (limit = options.delete(:limit))
               options.merge!(limit) if limit.is_a?(::Hash)
@@ -18,9 +18,9 @@ module ActiveRecord  # :nodoc:
 
             options[:limit] = ColumnDefinitionUtils.limit_from_options(geo_type, options)
             options[:spatial_type] = geo_type
-            column = super(name, base_type, options)
+            column = super(name, base_type, **options)
           else
-            column = super(name, type, options)
+            column = super(name, type, **options)
           end
 
           column


### PR DESCRIPTION
Ruby 2.7.0 was released December 25, 2019, and has some noisy [deprecation messages about keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

`activerecord-postgis-adapter` calls multiple methods from ActiveRecord that have kwargs as the last argument and produce warnings in stdout.

So, what's done here:

* Add Ruby 2.7 to Travis matrix
* Get rid of kwargs deprecation messages from postgis-adapter

We still need to wait for Rails team to release a new version of ActiveRecord which will also has fixes for it's own deprecation messages.