### PR TITLE
Fix SchemaStatements#initialize_type_map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ run `rake appraisal` or run the tests manually:
 
 ```
 BUNDLE_GEMFILE=./gemfiles/ar60.gemfile bundle
-BUNDLE_GEMFILE=./gemfiles/ar60.gemfile rake
+BUNDLE_GEMFILE=./gemfiles/ar60.gemfile bundle exec rake
 ```
 
 Make your changes and submit a pull request.

--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -85,8 +85,6 @@ module ActiveRecord
         end
 
         def initialize_type_map(map = type_map)
-          super
-
           %w(
             geography
             geometry
@@ -102,6 +100,8 @@ module ActiveRecord
               OID::Spatial.new(oid, sql_type)
             end
           end
+
+          super
         end
       end
     end

--- a/test/schema_statements_test.rb
+++ b/test/schema_statements_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SchemaStatementsTest < ActiveSupport::TestCase
+  def test_initialize_type_map
+    initialized_types = SpatialModel.connection.send(:type_map).keys
+
+    # PostGIS types must be initialized first, so
+    # ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#load_additional_types can use them.
+    # https://github.com/rails/rails/blob/8d57cb39a88787bb6cfb7e1c481556ef6d8ede7a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L593
+    assert_equal initialized_types.first(9), %w[
+      geography
+      geometry
+      geometry_collection
+      line_string
+      multi_line_string
+      multi_point
+      multi_polygon
+      st_point
+      st_polygon
+    ]
+  end
+end


### PR DESCRIPTION
Since the Rails 6 upgrade, we started seeing some random PostGIS
serialization/deserialization issues, debugging the issues shows that the
ActiveRecord connection `type_map` isn't initialized properly.
It does not contain the PostGIS OID type mappings after `initialize_type_map` has ended.

Usually, Rails would add missing OID mappings when encountered, however,
there are code paths that go around this (See [`lookup_cast_type_from_column`](https://github.com/rails/rails/blob/15748f6a052d4df68b6acf66456c181b42d9fe25/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L78)).
This is most likely a bug in Rails internals.

This patch fixes the [`initialize_type_map`](https://github.com/rgeo/activerecord-postgis-adapter/blob/cc0e3f53520feed0b43800d8ee86561ee03de413/lib/active_record/connection_adapters/postgis/schema_statements.rb#L87-L105) method by ensuring that
the specific PostGIS types are registered before calling `super` which
will then call [`load_additional_types`](https://github.com/rgeo/activerecord-postgis-adapter/blob/cc0e3f53520feed0b43800d8ee86561ee03de413/lib/active_record/connection_adapters/postgis/schema_statements.rb#L87-L105) and registers the other PostGIS OIDs.

This patch should solve #307 and #308.