### PR TITLE
Update Arel Module

### DIFF
--- a/lib/active_record/connection_adapters/postgis/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/postgis/arel_tosql.rb
@@ -20,10 +20,6 @@ module Arel  # :nodoc:
         FUNC_MAP[standard_name.downcase] || standard_name
       end
 
-      def visit_String(node, collector)
-        collector << "#{st_func('ST_WKTToSQL')}(#{quote(node)})"
-      end
-
       def visit_RGeo_ActiveRecord_SpatialNamedFunction(node, collector)
         aggregate(st_func(node.name), node, collector)
       end


### PR DESCRIPTION
Fixes #207 , #183 

Removes the `visit_String` method that was causing all strings passed directly into an `Arel` method to be wrapped with `ST_GeomFromEWKT`. Since `visit_String` was removed from `Arel` core, the expected behavior is that passing a string directly into a method will raise an error.

There is probably some work that can be done on `rgeo-activerecord` in regards to its `Arel` interface, but this at least gets the adapter up to date with current `Arel` behavior.