### PR TITLE
Use SVG version of Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/activerecord-postgis-adapter.svg)](https://badge.fury.io/rb/activerecord-postgis-adapter)
 [![Build Status](https://travis-ci.org/rgeo/activerecord-postgis-adapter.svg?branch=master)](https://travis-ci.org/rgeo/activerecord-postgis-adapter)
-[![Code Climate](https://codeclimate.com/github/rgeo/activerecord-postgis-adapter.png)](https://codeclimate.com/github/rgeo/activerecord-postgis-adapter)
+[![Maintainability](https://api.codeclimate.com/v1/badges/4444dc80a2cd6a37baa1/maintainability)](https://codeclimate.com/github/rgeo/activerecord-postgis-adapter/maintainability)
 
 The activerecord-postgis-adapter provides access to features
 of the PostGIS geospatial database from ActiveRecord. It extends


### PR DESCRIPTION
Apologies, my OCD.

You can check the code here: https://codeclimate.com/github/rgeo/activerecord-postgis-adapter/badges#maintainability-markdown

### Before (MacBook with Retina display):

![image](https://user-images.githubusercontent.com/556268/102685625-63571d80-41e2-11eb-9ab3-3b20a0ffc7d6.png)


### After (MacBook with Retina display):

![image](https://user-images.githubusercontent.com/556268/102685639-7669ed80-41e2-11eb-9934-9e9c6779a559.png)


https://github.com/tagliala/activerecord-postgis-adapter/tree/chore/use-svg-badge#postgis-activerecord-adapter