### PR TITLE
Update db:gis:setup Task for ActiveRecord 6.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,6 @@
+### 7.0.1 / 2021-01-13
+
+* Fix db:gis:setup task #329
 ### 7.0.0 / 2020-12-22
 
 * Add ActiveRecord 6.1 Compatability (tagliala) #324

--- a/lib/active_record/connection_adapters/postgis/databases.rake
+++ b/lib/active_record/connection_adapters/postgis/databases.rake
@@ -2,17 +2,17 @@
 
 namespace :db do
   namespace :gis do
-    desc "Setup PostGIS data in the database"
+    desc 'Setup PostGIS data in the database'
     task setup: [:load_config] do
       environments = [Rails.env]
-      environments << "test" if Rails.env.development?
+      environments << 'test' if Rails.env.development?
       environments.each do |environment|
         ActiveRecord::Base.configurations
-          .configs_for(env_name: environment)
-          .reject { |env| env.config["database"].blank? }
-          .each do |env|
-            ActiveRecord::ConnectionAdapters::PostGIS::PostGISDatabaseTasks.new(env.config).setup_gis
-          end
+                          .configs_for(env_name: environment)
+                          .reject { |env| env.configuration_hash['database'].blank? }
+                          .each do |env|
+          ActiveRecord::ConnectionAdapters::PostGIS::PostGISDatabaseTasks.new(env).setup_gis
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/postgis/version.rb
+++ b/lib/active_record/connection_adapters/postgis/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostGIS
-      VERSION = "7.0.0"
+      VERSION = "7.0.1"
     end
   end
 end


### PR DESCRIPTION
Fixes #328.

Missed this in testing for ActiveRecord 6.1 upgrade because it is in a Rake task and requires rails. The solution is passing the new `DatabaseConfig` object to the task instead of a plain hash.