### PR TITLE
Fix JRuby for ActiveRecord 6.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        ruby: [3.0, 2.7, 2.6, 2.5]
+        ruby: [3.0, 2.7, 2.6, 2.5, jruby]
         BUNDLE_GEMFILE:
           - gemfiles/ar61.gemfile
         pg: [9.6-3.0, 10-2.5, 11-3.0, 12-master, 13-master]

--- a/lib/active_record/connection_adapters/postgis/create_connection.rb
+++ b/lib/active_record/connection_adapters/postgis/create_connection.rb
@@ -10,7 +10,11 @@ module ActiveRecord  # :nodoc:
   module ConnectionHandling  # :nodoc:
     if RUBY_ENGINE == "jruby"
 
+      # modified from https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/postgresql/connection_methods.rb#L3
       def postgis_connection(config)
+        config = config.deep_dup
+        config = symbolize_keys_if_necessary(config)
+
         config[:adapter_class] = ConnectionAdapters::PostGISAdapter
         postgresql_connection(config)
       end

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -90,3 +90,21 @@ module ActiveRecord
     end
   end
 end
+
+# if using JRUBY, create ArJdbc::PostGIS module
+# and prepend it to the PostgreSQL adapter since
+# it is the default adapter_spec.
+# see: https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/postgresql/adapter.rb#27
+if RUBY_ENGINE == "jruby"
+  module ArJdbc
+    module PostGIS
+      ADAPTER_NAME = 'PostGIS'.freeze
+
+      def adapter_name
+        ADAPTER_NAME
+      end
+    end
+  end
+
+  ArJdbc::PostgreSQL.prepend(ArJdbc::PostGIS)
+end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -199,7 +199,7 @@ class BasicTest < ActiveSupport::TestCase
     rec.m_poly = wkt
     assert rec.save
     rec = SpatialModel.find(rec.id) # force reload
-    assert rec.m_poly.is_a?(RGeo::Geos::CAPIMultiPolygonImpl)
+    assert RGeo::Feature::MultiPolygon.check_type(rec.m_poly)
     assert_equal wkt, rec.m_poly.to_s
   end
 


### PR DESCRIPTION
- Modified the `postgis_connection` method to handle the frozen configuration hash.
- Prepended the `ArJdbc::PostgreSQL` adapter module with an `ArJdbc::PostGIS` module that specifies the `ADAPTER_NAME` as PostGIS.
- Changed `BasicTest#test_multi_polygon_column` to accept any `multi_polygon` not just a `CAPIMultiPolygon` since JRuby uses the GEOS FFI.