### PR TITLE
Access configuration_hash using symbols

### DIFF
--- a/lib/active_record/connection_adapters/postgis/databases.rake
+++ b/lib/active_record/connection_adapters/postgis/databases.rake
@@ -9,7 +9,7 @@ namespace :db do
       environments.each do |environment|
         ActiveRecord::Base.configurations
                           .configs_for(env_name: environment)
-                          .reject { |env| env.configuration_hash['database'].blank? }
+                          .reject { |env| env.configuration_hash[:database].blank? }
                           .each do |env|
           ActiveRecord::ConnectionAdapters::PostGIS::PostGISDatabaseTasks.new(env).setup_gis
         end


### PR DESCRIPTION
The previous code with the string 'database' does no longer work in current Rails versions.

Configuration hash uses symbols since Rails 6.1. See 
https://github.com/rails/rails/commit/ce9b197cc902ce8b72b7b3b5a3ec7e507fdba858

