### PR TITLE
Fix constants table truncation

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -35,6 +35,13 @@ module ActiveRecord
         end
 
         # override
+        # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L51
+        # Returns an array of table names defined in the database, without the PostGIS spatial constants
+        def tables
+          query_values(data_source_sql(type: "BASE TABLE"), "SCHEMA").reject {|t| t == 'spatial_ref_sys'}
+        end
+
+        # override
         # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L544
         #
         # returns Postgresql sql type string

--- a/test/schema_statements_test.rb
+++ b/test/schema_statements_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class SchemaStatementsTest < ActiveSupport::TestCase
+  parallelize
+
   def test_initialize_type_map
     initialized_types = SpatialModel.connection.send(:type_map).keys
 
@@ -21,4 +23,13 @@ class SchemaStatementsTest < ActiveSupport::TestCase
       st_polygon
     ]
   end
+
+  class TestRecord < ActiveRecord::Base
+    establish_test_connection
+  end
+
+  def test_spatial_constants_table_not_truncated
+    assert TestRecord.connection.execute('select * from spatial_ref_sys').count > 0
+  end
+
 end


### PR DESCRIPTION
This commit addresses an issue where when you parallelize the rails
tests, it truncates all of the tables available through the connection
which in the case of PostGIS includes the spatial_ref_sys which is bad
news.