### PR TITLE
Include PostGIS::DatabaseStatements in Adapter

### DIFF
--- a/lib/active_record/connection_adapters/postgis/database_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/database_statements.rb
@@ -2,12 +2,13 @@
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
-    module PostGISDatabaseStatements
-      def truncate_tables(*table_names)
-        table_names -= ["spatial_ref_sys"]
-        super(*table_names)
+    module PostGIS
+      module DatabaseStatements
+        def truncate_tables(*table_names)
+          table_names -= ["spatial_ref_sys"]
+          super(*table_names)
+        end
       end
     end
-    DatabaseStatements.prepend(PostGISDatabaseStatements)
   end
 end

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -8,11 +8,11 @@
 require "rgeo/active_record"
 
 require "active_record/connection_adapters"
-require "active_record/connection_adapters/postgis/database_statements"
 require "active_record/connection_adapters/postgresql_adapter"
 require "active_record/connection_adapters/postgis/version"
 require "active_record/connection_adapters/postgis/column_methods"
 require "active_record/connection_adapters/postgis/schema_statements"
+require "active_record/connection_adapters/postgis/database_statements"
 require "active_record/connection_adapters/postgis/spatial_column_info"
 require "active_record/connection_adapters/postgis/spatial_table_definition"
 require "active_record/connection_adapters/postgis/spatial_column"
@@ -54,6 +54,7 @@ module ActiveRecord
       DEFAULT_SRID = 0
 
       include PostGIS::SchemaStatements
+      include PostGIS::DatabaseStatements
 
       def arel_visitor # :nodoc:
         Arel::Visitors::PostGIS.new(self)


### PR DESCRIPTION
Fix for #342 and #337.

Instead of prepending the `DatabaseStatements` from #338, this includes it into the PostGIS adapter. Should fix issues where it would not be properly included in testing environments.