### PR TITLE
Fix Default Values

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -90,6 +90,14 @@ module ActiveRecord
         end
       end
 
+      def quote_default_expression(value, column)
+        if column.type == :geography || column.type == :geometry
+          quote(value)
+        else
+          super
+        end
+      end
+
       # PostGIS specific types
       [
         :geography,

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -102,6 +102,12 @@ class BasicTest < ActiveSupport::TestCase
     end
   end
 
+  def test_default_value
+    create_model
+    obj = SpatialModel.create
+    assert_equal factory.point(0, 0), obj.default_latlon
+  end
+
   def test_custom_factory
     klass = SpatialModel
     klass.connection.create_table(:spatial_models, force: true) do |t|
@@ -208,6 +214,7 @@ class BasicTest < ActiveSupport::TestCase
     SpatialModel.connection.create_table(:spatial_models, force: true) do |t|
       t.column "latlon", :st_point, srid: 3785
       t.column "latlon_geo", :st_point, srid: 4326, geographic: true
+      t.column "default_latlon", :st_point, srid: 0, default: 'POINT(0.0 0.0)'
     end
     SpatialModel.reset_column_information
   end


### PR DESCRIPTION
Fixes #344.

Overrides the `quote_default_expression` method to properly handle spatial data.