### PR TITLE
Activerecord 7 compatiblity

### DIFF
--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "activerecord", "~> 7.0.0"
+  spec.add_dependency "activerecord", "~> 7.0.0.alpha2"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
   spec.add_development_dependency "rake", "~> 12.0"

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "activerecord", "~> 6.1"
+  spec.add_dependency "activerecord", "~> 7.0.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Rails 7 will be released shortly, along with activerecord. 

Starting by changing gemspec version to `7.0.0.alpha2` to work with the gem. 

Any help is appreciated.