### PR TITLE
Support Activerecord 7.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,9 @@ jobs:
       BUNDLE_GEMFILE: ${{matrix.gemfile}}
     strategy:
       matrix:
-        ruby: ['3.0', '2.7', '2.6', '2.5', jruby]
+        ruby: ['3.0', '2.7']
         BUNDLE_GEMFILE:
-          - gemfiles/ar61.gemfile
+          - gemfiles/ar70.gemfile
         pg: [9.6-3.0, 10-2.5, 11-3.0, 12-master, 13-master]
     steps:
       - name: Set Up Actions

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 /gemfiles/*.gemfile.lock
 /travis/*.lock
 /test/database_local.yml
+.idea

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
   SuggestExtensions: false
 

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar61" do
-  gem "activerecord", "~> 6.1.0"
+appraise "ar70" do
+  gem "activerecord", "~> 7.0.0.alpha1"
 end

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ gem 'ffi-geos'
 
 _JRuby support for Rails 4.0 and 4.1 was added in version 2.2.0_
 
+#### Version 8.x supports ActiveRecord 7.0
+
+Requirements:
+
+```
+ActiveRecord 7.0
+Ruby 2.7.0+
+PostGIS 2.0+
+```
+
 #### Version 7.x supports ActiveRecord 6.1
 
 Requirements:

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "LICENSE.txt"]
   spec.platform = Gem::Platform::RUBY
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "activerecord", "~> 6.1"
+  spec.add_dependency "activerecord", "~> 7.0.alpha2"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.4"
   spec.add_development_dependency "mocha", "~> 1.1"
   spec.add_development_dependency "appraisal", "~> 2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  db:
+    image: postgis/postgis:11-3.0
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgis_adapter_test
+      POSTGRES_PASSWORD: postgres

--- a/gemfiles/ar70.gemfile
+++ b/gemfiles/ar70.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "pg", "~> 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "ffi-geos", platform: :jruby
-gem "activerecord", "~> 6.1.0"
+gem "activerecord", "~> 7.0.0.alpha1"
 
 gemspec path: "../"

--- a/lib/active_record/connection_adapters/postgis/version.rb
+++ b/lib/active_record/connection_adapters/postgis/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostGIS
-      VERSION = "7.1.1"
+      VERSION = "8.0.0"
     end
   end
 end


### PR DESCRIPTION
Disabled jruby testing until it fixed upstream. 

Add docker-compose.yml to spin a postgis server for local development.