### PR TITLE
overload type_to_sql

### DIFF
--- a/lib/active_record/connection_adapters/postgis/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_table_definition.rb
@@ -8,7 +8,13 @@ module ActiveRecord  # :nodoc:
 
         # super: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
         def new_column_definition(name, type, **options)
-          if (info = PostGISAdapter.spatial_column_options(type.to_sym))
+          col_type = if type.to_sym == :virtual
+            options[:type]
+          else
+            type
+          end
+
+          if (info = PostGISAdapter.spatial_column_options(col_type))
             if (limit = options.delete(:limit)) && limit.is_a?(::Hash)
               options.merge!(limit)
             end

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -356,6 +356,7 @@ class DDLTest < ActiveSupport::TestCase
   end
 
   def test_generated_geometry_column
+    skip "Virtual Columns are not supported in this version of PostGIS" unless SpatialModel.connection.supports_virtual_columns?
     klass.connection.create_table(:spatial_models, force: true) do |t|
       t.st_point :coordinates, limit: { srid: 4326 }
       t.virtual :generated_buffer, type: :st_polygon, limit: { srid: 4326 }, as: 'ST_Buffer(coordinates, 10)', stored: true

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -355,6 +355,17 @@ class DDLTest < ActiveSupport::TestCase
     assert_equal 'Comment test', col.comment
   end
 
+  def test_generated_geometry_column
+    klass.connection.create_table(:spatial_models, force: true) do |t|
+      t.st_point :coordinates, limit: { srid: 4326 }
+      t.virtual :generated_buffer, type: :st_polygon, limit: { srid: 4326 }, as: 'ST_Buffer(coordinates, 10)', stored: true
+    end
+    klass.reset_column_information
+    col = klass.columns.last
+    assert_equal(:geometry, col.type)
+    assert(col.virtual?)
+  end
+
   private
 
   def klass


### PR DESCRIPTION
This fixes when using generated geometry column from schema.rb

ref #369

`type_to_sql` had been removed in https://github.com/rgeo/activerecord-postgis-adapter/pull/360/files#diff-eeeb5e84f6023e4b440660467863dbed44712213c7c65db4e6fe401a3c219b1cL37-L57 as the adapter knows how to handle limits as strings. But in this situation, it is as a hash