### PR TITLE
Loosen activerecord dependency to allow rails 7.1.0.alpha

### DIFF
--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "activerecord", "~> 7.0.0"
+  spec.add_dependency "activerecord", ">= 7.0.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
It's impossible to install gem in rails app that is running on rails master right now, so I updated dependency similarly to [rgeo-activerecord](https://github.com/rgeo/rgeo-activerecord/blob/80edc88f649f6ec8488990cb99ddec0c7153091b/rgeo-activerecord.gemspec#L17), so that get will be compatible with rails 7.1
