### PR TITLE
Virtual column schema dump - default_function - Bring in recent postgressql adaptor change

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -11,7 +11,12 @@ module ActiveRecord
           column_name, type, default, notnull, oid, fmod, collation, comment, attgenerated = field
           type_metadata = fetch_type_metadata(column_name, type, oid.to_i, fmod.to_i)
           default_value = extract_value_from_default(default)
-          default_function = extract_default_function(default_value, default)
+
+          if attgenerated.present?
+            default_function = default
+          else
+            default_function = extract_default_function(default_value, default)
+          end
 
           if match = default_function&.match(/\Anextval\('"?(?<sequence_name>.+_(?<suffix>seq\d*))"?'::regclass\)\z/)
             serial = sequence_name_from_parts(table_name, column_name, match[:suffix]) == match[:sequence_name]


### PR DESCRIPTION
I switched from the official postgressql adaptor to this adaptor, and noticed that some virtual columns in my database started schema dumping incorrectly. In particular the `as` function would dump as nil 

```schema.rb
postgressql adaptor ->
  t.virtual "birthdate_text", type: :text, as: "birthdate", stored: true
postgis adaptor ->
  t.virtual "birthdate_text", type: :text, as: nil, stored: true
```
I did some investigation and it looks like your adaptor is missing a recent change @fatkodima made that fixes this issue. here

https://github.com/rails/rails/commit/7fa2720b09e044c79764329e3f0a23aab13ffb89

I copied his change and added a spec to cover the scenario. I tried to do my best to adhere to the style and format of the existing tests, but can make additional changes if needed. 

Thank you for your work on this project. 