### PR TITLE
Pass new identity attribute to preserve argument order

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -12,11 +12,11 @@ module ActiveRecord
           type_metadata = fetch_type_metadata(column_name, type, oid.to_i, fmod.to_i)
           default_value = extract_value_from_default(default)
 
-          default_function = if attgenerated.present?
-                               default
-                             else
-                               extract_default_function(default_value, default)
-                             end
+          if attgenerated.present?
+            default_function = default
+          else
+            default_function = extract_default_function(default_value, default)
+          end
 
           if (match = default_function&.match(/\Anextval\('"?(?<sequence_name>.+_(?<suffix>seq\d*))"?'::regclass\)\z/))
             serial = sequence_name_from_parts(table_name, column_name, match[:suffix]) == match[:sequence_name]

--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -8,15 +8,15 @@ module ActiveRecord
         # https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L662
         # Create a SpatialColumn instead of a PostgreSQL::Column
         def new_column_from_field(table_name, field, _definitions)
-          column_name, type, default, notnull, oid, fmod, collation, comment, attgenerated = field
+          column_name, type, default, notnull, oid, fmod, collation, comment, identity, attgenerated = field
           type_metadata = fetch_type_metadata(column_name, type, oid.to_i, fmod.to_i)
           default_value = extract_value_from_default(default)
 
-          if attgenerated.present?
-            default_function = default
-          else
-            default_function = extract_default_function(default_value, default)
-          end
+          default_function = if attgenerated.present?
+                               default
+                             else
+                               extract_default_function(default_value, default)
+                             end
 
           if (match = default_function&.match(/\Anextval\('"?(?<sequence_name>.+_(?<suffix>seq\d*))"?'::regclass\)\z/))
             serial = sequence_name_from_parts(table_name, column_name, match[:suffix]) == match[:sequence_name]
@@ -35,6 +35,7 @@ module ActiveRecord
             comment: comment.presence,
             serial: serial,
             generated: attgenerated,
+            identity: identity.presence,
             spatial: spatial
           )
         end

--- a/lib/active_record/connection_adapters/postgis/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column.rb
@@ -9,7 +9,7 @@ module ActiveRecord  # :nodoc:
         #   "Geography(Point,4326)"
         def initialize(name, default, sql_type_metadata = nil, null = true,
                        default_function = nil, collation: nil, comment: nil,
-                       serial: nil, generated: nil, spatial: nil)
+                       serial: nil, generated: nil, spatial: nil, identity: nil)
           @sql_type_metadata = sql_type_metadata
           @geographic = !!(sql_type_metadata.sql_type =~ /geography\(/i)
           if spatial
@@ -31,7 +31,7 @@ module ActiveRecord  # :nodoc:
             build_from_sql_type(sql_type_metadata.sql_type)
           end
           super(name, default, sql_type_metadata, null, default_function,
-                collation: collation, comment: comment, serial: serial, generated: generated)
+                collation: collation, comment: comment, serial: serial, generated: generated, identity: identity)
           if spatial? && @srid
             @limit = { srid: @srid, type: to_type_name(geometric_type) }
             @limit[:has_z] = true if @has_z


### PR DESCRIPTION
https://github.com/rails/rails/pull/49504 introduced a new `identity` argument on the `ActiveRecord::ConnectionAdapters::PostgreSQL::Column#initialize` method which is causing the dumping of virtual columns to be treated as identity columns. 

This PR updates the methods to match the new ones on the Postgres adapter.