### PR TITLE
add the ConnectionHandling module

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -24,6 +24,16 @@ require_relative "postgis/create_connection"
 # :startdoc:
 
 module ActiveRecord
+  module ConnectionHandling # :nodoc:
+    def postgis_adapter_class
+      ConnectionAdapters::PostGISAdapter
+    end
+
+    def postgis_connection(config)
+      postgis_adapter_class.new(config)
+    end
+  end
+
   module ConnectionAdapters
     class PostGISAdapter < PostgreSQLAdapter
       ADAPTER_NAME = 'PostGIS'


### PR DESCRIPTION
This is needed to support `db console` and probably others in rails 7.1 after https://github.com/rails/rails/pull/46093/ was merged.

This fixes (for me) #387 