### PR TITLE
fix: Rails 7.2 can't cast error.

### DIFF
--- a/lib/active_record/connection_adapters/postgis/spatial_column.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column.rb
@@ -31,7 +31,7 @@ module ActiveRecord  # :nodoc:
             build_from_sql_type(sql_type_metadata.sql_type)
           end
           super(name, default, sql_type_metadata, null, default_function,
-                collation: collation, comment: comment, serial: serial, generated: generated, identity: identity)
+                collation: collation, comment: comment, serial: serial, identity: identity, generated: generated)
           if spatial? && @srid
             @limit = { srid: @srid, type: to_type_name(geometric_type) }
             @limit[:has_z] = true if @has_z


### PR DESCRIPTION
As part of the updates made to the PostgreSQL adapter for Rails 7.2. Rails changed the argument order for instantiating column objects here https://github.com/rails/rails/blob/a11f0a63673d274c59c69c2688c63ba303b86193/activerecord/lib/active_record/connection_adapters/postgresql/column.rb#L9. Because the PostGIS adapter inherits from the PosgreSQL adapter it requires just a small update to the order of the arguments when instantiating new columns.

It should fix the cast errors reported in https://github.com/rgeo/activerecord-postgis-adapter/issues/402