### PR TITLE
Fix tests of #405 "Bump to 7.2.0"

### DIFF
--- a/test/cases/basic_test.rb
+++ b/test/cases/basic_test.rb
@@ -146,7 +146,7 @@ module PostGIS
                                                 has_z: false, has_m: false })
 
       # wrong factory for default
-      old_default = spatial_factory_store.default
+      old_default = spatial_factory_store.instance_variable_get :@default
       spatial_factory_store.default = RGeo::Geographic.spherical_factory(srid: 4326)
 
       object = klass.new

--- a/test/cases/basic_test.rb
+++ b/test/cases/basic_test.rb
@@ -18,7 +18,8 @@ module PostGIS
 
     def test_postgis_available
       assert_equal "PostGIS", SpatialModel.lease_connection.adapter_name
-      assert_equal SpatialModel.lease_connection.select_value("SELECT postgis_lib_version()"), SpatialModel.lease_connection.postgis_lib_version
+      expected_postgis_lib_version_value = SpatialModel.lease_connection.select_value("SELECT postgis_lib_version()")
+      assert_equal expected_postgis_lib_version_value, SpatialModel.lease_connection.postgis_lib_version
       valid_version = ["2.", "3."].any? { |major_ver| SpatialModel.lease_connection.postgis_lib_version.start_with? major_ver }
       assert valid_version
     end

--- a/test/cases/ddl_test.rb
+++ b/test/cases/ddl_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require "active_record/testing/query_assertions"
 
 module PostGIS
-  class DDLTest < ActiveRecord::TestCase
+  class DDLTest < ActiveSupport::TestCase
+    include ActiveRecord::Assertions::QueryAssertions
+
     def test_spatial_column_options
       [
         :geography,

--- a/test/cases/schema_statements_test.rb
+++ b/test/cases/schema_statements_test.rb
@@ -6,7 +6,7 @@ module PostGIS
   class SchemaStatementsTest < ActiveSupport::TestCase
     def test_initialize_type_map
       SpatialModel.with_connection do |connection|
-        assert connection.connected?
+        connection.connect!
         initialized_types = connection.send(:type_map).keys
 
         # PostGIS types must be initialized first, so


### PR DESCRIPTION
Fix tests setup and reset of #405:
Load current default spatial factory value as is instead of making rgeo produce one. Default factory produced by rgeo is not memoized by rgeo, but the set one is.
Resetting the default to a produced was fixing it to one fixed value.

Revert to use ActiveSupport::TestCase instead of ActiveRecord::TestCase on dd_test, it was causing the tests to attempt loading an misconfigured db connection.