### PR TITLE
Wrap gem loading to prevent prematurely loading ActiveRecord::Base

### DIFF
--- a/lib/activerecord-postgis-adapter.rb
+++ b/lib/activerecord-postgis-adapter.rb
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 
-require "active_record/connection_adapters/postgis_adapter"
+require "active_record"
+require "active_record/connection_adapters"
+require "rgeo/active_record"
+
+ActiveSupport.on_load(:active_record_postgresqladapter) do
+  require "active_record/connection_adapters/postgis_adapter"
+end


### PR DESCRIPTION
Without this, loading the gem can trigger loading of `ActiveRecord::Base` prior to configuration occurs in Rails loading. This can result in certain ActiveRecord configurations to be ignored. Wrapping with `on_load` defers loading until it is appropriate.