### PR TITLE
Fix loading issue with rake db:create on Rails 7.2

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -161,5 +161,4 @@ module ActiveRecord
     spatial_ref_sys
     topology
   ]
-  Tasks::DatabaseTasks.register_task(/postgis/, "ActiveRecord::Tasks::PostgreSQLDatabaseTasks")
 end

--- a/lib/activerecord-postgis-adapter.rb
+++ b/lib/activerecord-postgis-adapter.rb
@@ -4,3 +4,4 @@ require 'active_record'
 require "active_record/connection_adapters"
 require "rgeo/active_record"
 ActiveRecord::ConnectionAdapters.register("postgis", "ActiveRecord::ConnectionAdapters::PostGISAdapter", "active_record/connection_adapters/postgis_adapter")
+ActiveRecord::Tasks::DatabaseTasks.register_task(/postgis/, "ActiveRecord::Tasks::PostgreSQLDatabaseTasks")


### PR DESCRIPTION
Fixes #415.

This issue seems to only happen if a connection isn't created during startup. Not sure why other representative apps don't have this problem - there might be something in an initializer that creates the connection before trying to run the rake task. But from a pure perspective, the postgis adapter file may not load by the time the db:create tasks runs.

This PR moves the registration to the topmost file, which seems to solve this problem.