### PR TITLE
Add Rails 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      BUNDLE_GEMFILE: ${{matrix.gemfile}}
+      AR_VERSION: 8.0.0.1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://ruby-lang.org/en/downloads/branches
-        ruby: ["3.3", "3.2", "3.1"]
+        ruby: ["3.3", "3.2"]
         # https://www.postgresql.org/support/versioning/
         pg: [12-master, 13-master, 14-master, 15-master, 16-master]
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://ruby-lang.org/en/downloads/branches
-        ruby: ["3.3", "3.2"]
+        ruby: ["3.4", "3.3", "3.2"]
         # https://www.postgresql.org/support/versioning/
         pg: [12-master, 13-master, 14-master, 15-master, 16-master]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ Gemfile.lock
 /travis/*.lock
 /test/database_local.yml
 .idea
-debug.log
+debug.log*
 /test/db/*
+/test/storage/

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.platform = Gem::Platform::RUBY
 
   # ruby-lang.org/en/downloads/branches
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
-  spec.add_dependency "activerecord", "~> 7.2.0"
+  spec.add_dependency "activerecord", "~> 8.0.0"
   spec.add_dependency "rgeo-activerecord", "~> 8.0.0"
 
   spec.add_development_dependency "rake", "~> 13.0"

--- a/test/database.yml
+++ b/test/database.yml
@@ -7,7 +7,6 @@ connections:
       username: <%= ENV["PGUSER"] || "postgres" %>
       password: <%= ENV["PGPASSWORD"] || "" %>
       setup: default
-      schema_search_path: public
     arunit2:
       host: <%= ENV["PGHOST"] || "127.0.0.1" %>
       port: <%= ENV["PGPORT"] || "5432" %>
@@ -15,7 +14,6 @@ connections:
       username: <%= ENV["PGUSER"] || "postgres" %>
       password: <%= ENV["PGPASSWORD"] || "" %>
       setup: default
-      schema_search_path: public
     arunit_without_prepared_statements:
       min_messages: warning
       prepared_statements: false
@@ -25,4 +23,3 @@ connections:
       username: <%= ENV["PGUSER"] || "postgres" %>
       password: <%= ENV["PGPASSWORD"] || "" %>
       setup: default
-      schema_search_path: public

--- a/test/excludes/ActiveRecord/ConnectionAdapters/RegistrationIsolatedTest.rb
+++ b/test/excludes/ActiveRecord/ConnectionAdapters/RegistrationIsolatedTest.rb
@@ -1,0 +1,1 @@
+exclude "test_#resolve_raises_if_the_adapter_is_using_the_pre_7.2_adapter_registration_API", TRIAGE_MSG

--- a/test/excludes/CounterCacheTest.rb
+++ b/test/excludes/CounterCacheTest.rb
@@ -30,7 +30,7 @@ exclude "test_increment_counter_by_specific_amount", TRIAGE_MSG
 exclude "test_decrement_counter", TRIAGE_MSG
 exclude "test_reset_counters_with_touch:_true", TRIAGE_MSG
 exclude "test_reset_the_right_counter_if_two_have_the_same_foreign_key", TRIAGE_MSG
-exclude "test_inactive_conter_cache", TRIAGE_MSG
+exclude "test_inactive_counter_cache", TRIAGE_MSG
 exclude "test_update_counters_of_multiple_records", TRIAGE_MSG
 exclude "test_counters_are_updated_both_in_memory_and_in_the_database_on_create", TRIAGE_MSG
 exclude "test_update_counter_with_initial_null_value", TRIAGE_MSG
@@ -47,7 +47,7 @@ exclude "test_removing_association_updates_counter", TRIAGE_MSG
 exclude "test_reset_counters_with_touch:_:written_on", TRIAGE_MSG
 exclude "test_reset_counters_for_cpk_model", TRIAGE_MSG
 exclude "test_reset_the_right_counter_if_two_have_the_same_class_name", TRIAGE_MSG
-exclude "test_active_conter_cache", TRIAGE_MSG
+exclude "test_active_counter_cache", TRIAGE_MSG
 exclude "test_increment_counters_with_touch:_:written_on", TRIAGE_MSG
 exclude "test_update_multiple_counters_with_touch:_:written_on", TRIAGE_MSG
 exclude "test_counter_cache_column?", TRIAGE_MSG

--- a/test/excludes/SchemaDumperTest.rb
+++ b/test/excludes/SchemaDumperTest.rb
@@ -1,2 +1,5 @@
 exclude "test_schema_dump_with_timestamptz_datetime_format", TRIAGE_MSG
 exclude "test_schema_dump_when_changing_datetime_type_for_an_existing_app", TRIAGE_MSG
+if ActiveRecord::Base.lease_connection.pool.server_version(ActiveRecord::Base.lease_connection) < 15_00_00
+  exclude "test_schema_dumps_unique_constraints", TRIAGE_MSG
+end


### PR DESCRIPTION
This PR is #419, plus:

* Remove ruby 3.1 from the test matrix, since rails 8 requires ruby 3.2
* Add ruby 3.4 to the test matrix
* Update the .gitignore file