### PR TITLE
Fix AR type cast to mirror quoting

### DIFF
--- a/lib/active_record/connection_adapters/postgis/quoting.rb
+++ b/lib/active_record/connection_adapters/postgis/quoting.rb
@@ -5,8 +5,9 @@ module ActiveRecord
     module PostGIS
       module Quoting
         def type_cast(value)
-          case value
-          when RGeo::Feature::Instance
+          if RGeo::Feature::Geometry.check_type(value)
+            RGeo::WKRep::WKBGenerator.new(hex_format: true, type_format: :ewkb, emit_ewkb_srid: true).generate(value)
+          elsif value.is_a?(RGeo::Cartesian::BoundingBox)
             value.to_s
           else
             super


### PR DESCRIPTION
It seems wrong that

```ruby
SpatialModel.where("ST_DWITHIN(latlon_geo, ?, 500)", geographic_factory.point(-72.099, 42.099)).to_sql
```

uses the EWKB format but when the query is actually executed it uses `to_s` which uses the WKT without passing any SRID.  This was causing me issues for me with preprepared statements but I couldn't create a simple text.  I do think this gem should pass the SRID of bindings though.

I'm not very happy with the test I've written here.  I looked `.values_for_queries` or looking at the arel but the binds haven't been type_cast at this point so I've used explain.