### PR TITLE
Added back Ruby 2.7 support for 9.0-stable (AR 7.1).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-head, '3.2', '3.1', '3.0']
+        ruby: [ruby-head, '3.2', '3.1', '3.0', '2.7']
         pg: [11-3.0, 12-master, 13-master, 14-master, 15-master]
     steps:
       - name: Set Up Actions

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
   SuggestExtensions: false
   NewCops: enable

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _JRuby support for Rails 4.0 and 4.1 was added in version 2.2.0_
 
 ```
 ActiveRecord 7.1
-Ruby 3.0.0+
+Ruby 2.7.0+
 PostGIS 2.0+
 ```
 

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "LICENSE.txt"]
   spec.platform = Gem::Platform::RUBY
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_dependency "activerecord", "~> 7.1.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"


### PR DESCRIPTION
**- What is it good for**

Unfortunately the support for Ruby 2.7 on the 9.x branch which supports ActiveRecord 7.1 was cut off. The required minimum Ruby version is 3.0. Rails (including AR) on the other hand [supports Ruby 2.7](https://github.com/rails/rails/blob/7-1-stable/rails.gemspec#L12), without issues (also tested via BuildKite). This patch brings back the Ruby 2.7 support for the 9.x branch in order to be compatible with ActiveRecord 7.1. The issue occured for me while upgrading an application from Rails 6.1 to 7.1 (the last version with Ruby 2.7 support).

**- What I did**

Just re-enabled the Ruby 2.7 support on CI and lowered the minimum required Ruby version on the gemspec, and the Rubocop config. I've already created a testing branch with Ruby 2.7-3.4 to verify the code base does not need any modifications, [tested via CI](https://github.com/Jack12816/activerecord-postgis-adapter/actions/runs/13006623590), [2nd test](https://github.com/Jack12816/activerecord-postgis-adapter/actions/runs/13006526472/job/36274521279).

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/99ae307b-9394-4364-802c-ab0db189b45b)
