### PR TITLE
Fix RGeo feature quoting with WKB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ AR_VERSION=7.0.1 bundle exec rake test
 
 To run a specific test, use the `POSTGIS_TEST_FILES` environment variable:
 
-`POSTGIS_TEST_FILES=test/cases/ddl_test.rb bundle exec rake`
+`POSTGIS_TEST_FILES=test/cases/ddl_test.rb bundle exec rake test:postgis`
 
 If you are testing a feature against the ActiveRecord test suite run:
 

--- a/lib/active_record/connection_adapters/postgis/quoting.rb
+++ b/lib/active_record/connection_adapters/postgis/quoting.rb
@@ -7,7 +7,9 @@ module ActiveRecord
         def type_cast(value)
           case value
           when RGeo::Feature::Instance
-            value.to_s
+            RGeo::WKRep::WKBGenerator
+              .new(hex_format: true, type_format: :ewkb, emit_ewkb_srid: true)
+              .generate(value)
           else
             super
           end

--- a/test/cases/spatial_queries_test.rb
+++ b/test/cases/spatial_queries_test.rb
@@ -122,6 +122,14 @@ module PostGIS
       assert_equal 1, SpatialModel.where("ST_DWITHIN(latlon_geo, ?, 500)", geographic_factory.point(-72.099, 42.099)).count
     end
 
+    def test_geo_safe_where_with_srids
+      create_model
+      center  = RGeo::Geos.factory(srid: 4326).point(3.833, 43.698)
+      polygon = RGeo::Geos.factory(srid: 4326).parse_wkt("POLYGON ((3.9 43.68, 3.8 43.62, 3.77 43.75, 3.9 43.68))")
+      SpatialModel.create!(polygon: polygon)
+      assert_equal 1, SpatialModel.where("ST_Within(?, polygon)", center).count
+    end
+
     private
 
     def create_model
@@ -130,6 +138,7 @@ module PostGIS
         t.column "latlon_geo", :st_point, srid: 4326, geographic: true
         t.column "points", :multi_point, srid: 3785
         t.column "path", :line_string, srid: 3785
+        t.column "polygon", :st_polygon, srid: 4326
       end
       SpatialModel.reset_column_information
     end


### PR DESCRIPTION
Fix #429

This patch is based on `10.0-stable` branch since the issue appeared on AR 7.1 / PGis Adapter 10.x

I was not able to launch `bundle exec rake` with success (even before patching).
I was only able to test this patch with `bundle exec rake test:postgis`.