### PR TITLE
fix: missing @srid instance variable in v11.1 causes breaking change

### DIFF
--- a/lib/active_record/connection_adapters/postgis/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/postgis/oid/spatial.rb
@@ -12,6 +12,7 @@ module ActiveRecord
           def initialize(geo_type: "geometry", srid: 0, has_z: false, has_m: false, geographic: false)
             super()
             @geographic = geographic.freeze
+            @srid = srid.freeze
             @factory_attrs = {
               geo_type: geo_type.underscore.freeze,
               has_m: has_m.freeze,


### PR DESCRIPTION
`def wkt_parser(string)` in `ActiveRecord::ConnectionAdapters::PostGIS::OID::Spatial` internally uses `@srid`:

```ruby
          def wkt_parser(string)
            if binary_string?(string)
              RGeo::WKRep::WKBParser.new(spatial_factory, support_ewkb: true, default_srid: @srid)
            else
              RGeo::WKRep::WKTParser.new(spatial_factory, support_ewkt: true, default_srid: @srid)
            end
          end
```

In 11.0 to 11.1 change, due to initializer refactoring, the `@srid` instance variable was removed from the initializer, but `def wkt_parser(string)` still uses it (so it's always `nil`, which breaks things in some situations).

Adding `@srid` back as a hotfix for the breaking change.