### PR TITLE
feat: add Ruby 4.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://ruby-lang.org/en/downloads/branches
-        ruby: ['3.4', '3.3', '3.2']
+        ruby: ['4.0', '3.4', '3.3', '3.2']
         # https://www.postgresql.org/support/versioning/
         # See (and update!) `pg_targets` above for selected pg versions.
         pg: ${{ fromJson(needs.orchestrate.outputs.postgis_tags) }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 4.0
   DisplayCopNames: true
   SuggestExtensions: false
   NewCops: enable

--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+### 11.2.0 / 2026-06-09
+
+* Ruby 4.0 support: add Ruby 4.0 to CI matrix
+* Replace `=~` + `Regexp.last_match` with thread-safe `.match()` / `.match?()` throughout
+* Fix EWKT regex in `arel_tosql.rb` (`[\d+]{0,}` → `\d+`)
+* Update RuboCop `TargetRubyVersion` to 4.0
+
 ### 11.1.1 / 2025-11-27
 
 * Fix usage of `OID::Spatial#wkt_parser` (oleksii-leonov)

--- a/lib/active_record/connection_adapters/postgis/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/postgis/arel_tosql.rb
@@ -7,7 +7,7 @@ module RGeo
     module SpatialToPostGISSql
       def visit_in_spatial_context(node, collector)
         # Use ST_GeomFromEWKT for EWKT geometries
-        if node.is_a?(String) && node =~ /SRID=[\d+]{0,};/
+        if node.is_a?(String) && node.match?(/SRID=\d+;/)
           collector << "#{st_func('ST_GeomFromEWKT')}(#{quote(node)})"
         else
           super(node, collector)

--- a/lib/active_record/connection_adapters/postgis/column.rb
+++ b/lib/active_record/connection_adapters/postgis/column.rb
@@ -12,7 +12,7 @@ module ActiveRecord  # :nodoc:
                        serial: nil, generated: nil, spatial: nil, identity: nil)
           super(name, cast_type, default, sql_type_metadata, null, default_function,
                 collation: collation, comment: comment, serial: serial, generated: generated, identity: identity)
-          @geographic = !!(sql_type_metadata.sql_type =~ /geography\(/i)
+          @geographic = sql_type_metadata.sql_type.match?(/geography\(/i)
           if spatial
             # This case comes from an entry in the geometry_columns table
             set_geometric_type_from_name(spatial[:type])
@@ -24,9 +24,9 @@ module ActiveRecord  # :nodoc:
             @srid = 4326
             @has_z = @has_m = false
             build_from_sql_type(sql_type_metadata.sql_type)
-          elsif sql_type =~ /geography|geometry|point|linestring|polygon/i
+          elsif sql_type.match?(/geography|geometry|point|linestring|polygon/i)
             build_from_sql_type(sql_type_metadata.sql_type)
-          elsif sql_type_metadata.sql_type =~ /geography|geometry|point|linestring|polygon/i
+          elsif sql_type_metadata.sql_type.match?(/geography|geometry|point|linestring|polygon/i)
             # A geometry column with no geometry_columns entry.
             # @geometric_type = geo_type_from_sql_type(sql_type)
             build_from_sql_type(sql_type_metadata.sql_type)

--- a/lib/active_record/connection_adapters/postgis/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/postgis/oid/spatial.rb
@@ -35,17 +35,17 @@ module ActiveRecord
             has_z = false
             has_m = false
 
-            if sql_type =~ /(geography|geometry)\((.*)\)$/i
+            if (outer_match = sql_type.match(/(geography|geometry)\((.*)\)$/i))
               # geometry(Point)
               # geometry(Point,4326)
-              params = Regexp.last_match(2).split(",")
-              if params.first =~ /([a-z]+[^zm])(z?)(m?)/i
-                has_z = Regexp.last_match(2).length > 0
-                has_m = Regexp.last_match(3).length > 0
-                geo_type = Regexp.last_match(1)
+              params = outer_match[2].split(",")
+              if (type_match = params.first.match(/([a-z]+[^zm])(z?)(m?)/i))
+                has_z = !type_match[2].empty?
+                has_m = !type_match[3].empty?
+                geo_type = type_match[1]
               end
-              if params.last =~ /(\d+)/
-                srid = Regexp.last_match(1).to_i
+              if (srid_match = params.last.match(/(\d+)/))
+                srid = srid_match[1].to_i
               end
             else
               # geometry

--- a/lib/active_record/connection_adapters/postgis/spatial_column_info.rb
+++ b/lib/active_record/connection_adapters/postgis/spatial_column_info.rb
@@ -19,7 +19,7 @@ module ActiveRecord  # :nodoc:
             name = row[0]
             type = row[3]
             dimension = row[1].to_i
-            has_m = !!(type =~ /m$/i)
+            has_m = type.match?(/m$/i)
             type.sub!(/m$/, "")
             has_z = dimension > 3 || (dimension == 3 && !has_m)
             result[name] = {

--- a/lib/active_record/connection_adapters/postgis/version.rb
+++ b/lib/active_record/connection_adapters/postgis/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostGIS
-      VERSION = "11.1.1"
+      VERSION = "11.2.0"
     end
   end
 end


### PR DESCRIPTION
Add Ruby 4.0 support

### Changes

**CI & tooling**
- Add `'4.0'` to the Ruby version matrix in `.github/workflows/tests.yml`
- Update RuboCop `TargetRubyVersion` from `3.0` to `4.0`
- Bump version to `11.2.0`

**Code modernization (Ruby 4 best practices)**

Replace `=~` + `Regexp.last_match` with thread-safe `.match()` / `.match?()` throughout:

- `oid/spatial.rb` — `parse_sql_type` now uses local match variables instead of
  relying on the global `Regexp.last_match` side-effect
- `column.rb` — replace `!!(str =~ /regex/)` with `str.match?(/regex/)`
- `spatial_column_info.rb` — same pattern
- `arel_tosql.rb` — use `.match?()` and fix the regex `[\d+]{0,}` → `\d+`
  (the original character class `[\d+]` was unintentional)

### Testing

Tested locally against PostGIS 17-3.5 on **Ruby 4.0.5**.
All 67 adapter-specific tests pass (`rake test:postgis`).
The single pre-existing failure in the full suite (`BasicsTest#test_mutating_time_objects`)
is a timezone issue in the Rails test suite itself, unrelated to this PR —
it fails identically on the unmodified `master` on both Ruby 3.4.3 and Ruby 4.0.5.